### PR TITLE
feat(investigation): add extended "thinking" mode with streaming output

### DIFF
--- a/internal/application/usecase/alert_investigation.go
+++ b/internal/application/usecase/alert_investigation.go
@@ -18,6 +18,12 @@ type ConversationServiceInterface interface {
 	StartConversation(ctx context.Context) (string, error)
 	AddUserMessage(ctx context.Context, sessionID, content string) (*entity.Message, error)
 	ProcessAssistantResponse(ctx context.Context, sessionID string) (*entity.Message, []port.ToolCallInfo, error)
+	ProcessAssistantResponseStreaming(
+		ctx context.Context,
+		sessionID string,
+		textCallback port.StreamCallback,
+		thinkingCallback port.ThinkingCallback,
+	) (*entity.Message, []port.ToolCallInfo, error)
 	AddToolResultMessage(ctx context.Context, sessionID string, toolResults []entity.ToolResult) error
 	EndConversation(ctx context.Context, sessionID string) error
 	SetCustomSystemPrompt(ctx context.Context, sessionID, prompt string) error
@@ -188,6 +194,9 @@ type AlertInvestigationUseCaseConfig struct {
 	EscalateOnErrors     int           // Escalate after this many consecutive errors
 	AutoStartForCritical bool          // Automatically start investigations for critical alerts
 	EnableSafetyChecks   bool          // Enable command safety validation
+	ExtendedThinking     bool          // Enable extended thinking for investigations
+	ThinkingBudget       int64         // Token budget for thinking (default: 10000)
+	ShowThinking         bool          // Display thinking output in logs
 }
 
 // AlertInvestigationUseCase orchestrates AI-driven alert investigations.

--- a/internal/application/usecase/alert_investigation_test.go
+++ b/internal/application/usecase/alert_investigation_test.go
@@ -1818,6 +1818,15 @@ func (m *mockConversationServiceWithThinking) ProcessAssistantResponse(
 	return nil, nil, nil
 }
 
+func (m *mockConversationServiceWithThinking) ProcessAssistantResponseStreaming(
+	_ context.Context,
+	_ string,
+	_ port.StreamCallback,
+	_ port.ThinkingCallback,
+) (*entity.Message, []port.ToolCallInfo, error) {
+	return nil, nil, nil
+}
+
 func (m *mockConversationServiceWithThinking) AddToolResultMessage(
 	ctx context.Context,
 	sessionID string,

--- a/internal/application/usecase/subagent_runner_ai_context_test.go
+++ b/internal/application/usecase/subagent_runner_ai_context_test.go
@@ -110,6 +110,16 @@ func (m *contextTrackingConvServiceMock) ProcessAssistantResponse(
 	return msg, toolCalls, nil
 }
 
+func (m *contextTrackingConvServiceMock) ProcessAssistantResponseStreaming(
+	ctx context.Context,
+	sessionID string,
+	_ port.StreamCallback,
+	_ port.ThinkingCallback,
+) (*entity.Message, []port.ToolCallInfo, error) {
+	// Delegate to non-streaming version for testing
+	return m.ProcessAssistantResponse(ctx, sessionID)
+}
+
 func (m *contextTrackingConvServiceMock) AddToolResultMessage(
 	_ context.Context,
 	_ string,

--- a/internal/application/usecase/subagent_runner_test.go
+++ b/internal/application/usecase/subagent_runner_test.go
@@ -120,6 +120,16 @@ func (m *subagentRunnerConvServiceMock) ProcessAssistantResponse(
 	return msg, toolCalls, nil
 }
 
+func (m *subagentRunnerConvServiceMock) ProcessAssistantResponseStreaming(
+	ctx context.Context,
+	sessionID string,
+	_ port.StreamCallback,
+	_ port.ThinkingCallback,
+) (*entity.Message, []port.ToolCallInfo, error) {
+	// Delegate to non-streaming version for testing
+	return m.ProcessAssistantResponse(ctx, sessionID)
+}
+
 func (m *subagentRunnerConvServiceMock) AddToolResultMessage(
 	_ context.Context,
 	_ string,

--- a/internal/domain/service/conversation_service.go
+++ b/internal/domain/service/conversation_service.go
@@ -273,6 +273,11 @@ func (cs *ConversationService) prepareAIRequest(
 		})
 	}
 
+	// Add thinking mode info to context if enabled
+	if thinkingInfo, err := cs.GetThinkingMode(sessionID); err == nil && thinkingInfo.Enabled {
+		ctx = port.WithThinkingMode(ctx, thinkingInfo)
+	}
+
 	return conversation, messageParams, toolParams, ctx, nil
 }
 

--- a/internal/infrastructure/config/container.go
+++ b/internal/infrastructure/config/container.go
@@ -227,7 +227,10 @@ func createInvestigationComponents(
 			"report_investigation",
 			"task", "delegate",
 		},
-		BlockedCommands: []string{"rm -rf", "dd if=", "mkfs"},
+		BlockedCommands:  []string{"rm -rf", "dd if=", "mkfs"},
+		ExtendedThinking: cfg.ExtendedThinking,
+		ThinkingBudget:   cfg.ThinkingBudget,
+		ShowThinking:     cfg.ShowThinking,
 	}
 	investigationUseCase := usecase.NewAlertInvestigationUseCaseWithConfig(invConfig)
 


### PR DESCRIPTION
- introduce ExtendedThinking, ThinkingBudget (default 10000) and ShowThinking config flags
- wire config through container to the investigation use case
- add ProcessAssistantResponseStreaming to conversation service interface and mocks
- InvestigationRunner: set thinking mode via SetThinkingMode when enabled and use streaming path to show thinking output to stderr
- ConversationService: inject thinking mode into AI request context
- add tests for thinking mode behavior and update existing mocks/tests accordingly