### PR TITLE
fix(yaml_parser): preserve body content when extracting YAML frontmatter

### DIFF
--- a/internal/domain/entity/skill_test.go
+++ b/internal/domain/entity/skill_test.go
@@ -378,6 +378,47 @@ func TestSkill_ValidateDirectoryName_NonMatchingNames(t *testing.T) {
 	}
 }
 
+func TestSkill_ParseSkillFromYAML_RawContent(t *testing.T) {
+	tests := []struct {
+		name           string
+		yaml           string
+		wantRawContent string
+	}{
+		{
+			name:           "body text preserved exactly",
+			yaml:           "---\nname: my-skill\ndescription: A skill\n---\nThis is the body content.",
+			wantRawContent: "This is the body content.",
+		},
+		{
+			name:           "multi-line body first 3 chars preserved",
+			yaml:           "---\nname: my-skill\ndescription: A skill\n---\n# Header\nSome content\nMore content",
+			wantRawContent: "# Header\nSome content\nMore content",
+		},
+		{
+			name:           "no body content gives empty string",
+			yaml:           "---\nname: my-skill\ndescription: A skill\n---\n",
+			wantRawContent: "",
+		},
+		{
+			name:           "body starting with special characters preserved",
+			yaml:           "---\nname: my-skill\ndescription: A skill\n---\n# Header starts here",
+			wantRawContent: "# Header starts here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skill, err := ParseSkillFromYAML(tt.yaml)
+			if err != nil {
+				t.Fatalf("ParseSkillFromYAML() returned unexpected error: %v", err)
+			}
+			if skill.RawContent != tt.wantRawContent {
+				t.Errorf("ParseSkillFromYAML() RawContent = %q, want %q", skill.RawContent, tt.wantRawContent)
+			}
+		})
+	}
+}
+
 func TestSkill_ValidateDirectoryName_EmptyDirName(t *testing.T) {
 	skill := Skill{
 		Name:        "test-skill",

--- a/internal/domain/entity/yaml_parser.go
+++ b/internal/domain/entity/yaml_parser.go
@@ -8,7 +8,7 @@ import (
 // extractFrontmatter extracts YAML frontmatter from content enclosed in --- markers.
 // Returns the frontmatter content (without --- markers) and the remaining content after frontmatter.
 // Returns an error if the frontmatter format is invalid.
-func extractFrontmatter(content string) (frontmatter, remainingContent string, err error) {
+func extractFrontmatter(content string) (string, string, error) {
 	content = strings.TrimSpace(content)
 	if !strings.HasPrefix(content, "---") {
 		return "", "", errors.New("invalid YAML frontmatter: missing opening ---")
@@ -22,6 +22,9 @@ func extractFrontmatter(content string) (frontmatter, remainingContent string, e
 		if firstLineEnd == -1 {
 			return "", "", errors.New("invalid YAML frontmatter: missing closing ---")
 		}
+	} else {
+		// Convert substring index to full string index
+		firstLineEnd += 3
 	}
 
 	// Get the frontmatter part
@@ -29,7 +32,7 @@ func extractFrontmatter(content string) (frontmatter, remainingContent string, e
 	frontmatterRaw := content[:frontmatterEnd]
 
 	// Get the content after frontmatter
-	remaining := strings.TrimSpace(content[frontmatterEnd+3:])
+	remaining := strings.TrimSpace(content[frontmatterEnd:])
 
 	// Remove the opening and closing --- from frontmatter
 	frontmatterRaw = strings.TrimPrefix(frontmatterRaw, "---")


### PR DESCRIPTION
Adjust extractFrontmatter signature and index/trimming logic so the remaining content after the closing '---' is not truncated. Add unit tests (TestSkill_ParseSkillFromYAML_RawContent) to verify RawContent is preserved for empty, multi-line and special-character bodies.