### PR TITLE
chore(ci): add GH Actions workflow, Dockerfile, .dockerignore and k8s…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Version control
+.git
+.github
+
+# Agent/AI working directories
+.agent
+.claude
+.gemini
+
+# IDE
+.idea
+
+# Documentation (not needed in image)
+*.md
+REVIEW-*.md
+
+# Local binary artifacts
+code-agent-demo
+agent
+cli
+
+# Build artifacts
+vendor
+*.exe
+*.dll
+*.so
+*.dylib
+*.test
+
+# Data and logs
+data/
+logs/
+*.log
+
+# Deployment manifests (not needed in image)
+deploy/
+
+# Untracked work-in-progress
+conductor/
+
+# Demo files
+demo.*
+
+# Prevent real config with potential secrets from being baked into image
+config/alert-sources.yaml
+
+# Skills and agents directories are needed at runtime
+# so they are NOT ignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Format check
+        run: |
+          if [ -n "$(gofmt -l .)" ]; then
+            echo "The following files are not formatted:"
+            gofmt -l .
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race ./...
+
+  build-image:
+    name: Build & Push Image
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            REVISION=${{ github.sha }}
+            CREATED=${{ github.event.head_commit.timestamp }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# Stage 1: Build the Go binary
+FROM golang:1.24.11-bookworm AS builder
+
+WORKDIR /build
+
+# Copy dependency files first for layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /code-agent-demo ./cmd/cli
+
+# Stage 2: Minimal runtime image
+FROM alpine:3.21
+
+# Install runtime dependencies needed for AI investigation tool execution
+RUN apk add --no-cache \
+    ca-certificates \
+    tzdata \
+    bash \
+    coreutils \
+    curl
+
+# Create non-root user (UID 10001 to avoid conflicts with system UIDs)
+RUN adduser -D -u 10001 agent
+
+# OCI image labels
+ARG REVISION=unknown
+ARG CREATED=unknown
+LABEL org.opencontainers.image.source="https://github.com/Anthony-Bible/code-agent-demo" \
+      org.opencontainers.image.description="AI coding agent webhook server" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"
+
+# Copy binary from builder
+COPY --from=builder /code-agent-demo /app/code-agent-demo
+
+# Copy skills and agents directories if they exist
+COPY --from=builder /build/skills/ /app/skills/
+COPY --from=builder /build/agents/ /app/agents/
+COPY --from=builder /build/config/alert-sources.example.yaml /app/config/alert-sources.example.yaml
+
+# Create writable directories the app needs at runtime
+RUN mkdir -p /app/.agent /app/.agent/investigations && \
+    chown -R agent:agent /app
+
+WORKDIR /app
+
+EXPOSE 8080
+
+USER agent
+
+ENTRYPOINT ["/app/code-agent-demo"]
+CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Go-based AI-powered alert investigation agent built with hexagonal (clean) arc
   - [Skills](#skills)
   - [Subagents](#subagent-system)
   - [Alerts & Investigations](#alerts--investigations)
+- [Kubernetes Deployment](#kubernetes-deployment)
 - [Configuration](#configuration)
 - [Architecture](#architecture)
 - [Contributing](CONTRIBUTING.md)
@@ -539,6 +540,138 @@ Investigation escalated to human review:
 - Confidence: 0.45
 - Findings: 3 observations, no definitive root cause
 - Recommended actions: Manual log inspection required
+```
+
+---
+
+### Kubernetes Deployment
+
+The application can be deployed to Kubernetes using the provided manifests and Kustomize. Kustomize is used to pin immutable image tags at deploy time, ensuring reliable rollbacks.
+
+`★ Insight ─────────────────────────────────────`
+**Kustomize Image Tagging**: Kustomize generates manifests at runtime by merging and transforming resources. The `images:` field in `kustomization.yaml` declares an image target that can be overridden at deploy time using `kustomize edit set image`. The git-tracked `deployment.yaml` uses `:latest` as a placeholder, while `kustomize build` substitutes the actual immutable SHA tag like `sha-a1b2c3d` before applying to Kubernetes. This pattern keeps git history clean while enabling reliable deployments.
+
+**Kubernetes Security**: The deployment includes several security best practices: `automountServiceAccountToken: false` (no implicit RBAC access), `readOnlyRootFilesystem: true` (immutability), dropping all Linux capabilities, and running as non-root user (10001). The alert sources configuration is injected via ConfigMap to avoid baking secrets into images.
+`─────────────────────────────────────────────────`
+
+#### Prerequisites
+
+- **Kubernetes cluster** (v1.20+)
+- **kubectl** configured to access your cluster
+- **kustomize** installed (`brew install kustomize` or `go install sigs.k8s.io/kustomize/kustomize/v5@latest`)
+
+#### Deployment Overview
+
+The deployment includes:
+
+| Resource | Description |
+|----------|-------------|
+| `namespace.yaml` | Kubernetes namespace (`code-agent`) |
+| `configmap.yaml` | Environment configuration (model, tokens, safety settings) |
+| `configmap-alert-sources.yaml` | Alert sources configuration (Prometheus, GCP Monitoring) |
+| `deployment.yaml` | Deployment manifest with security hardening |
+| `service.yaml` | Service to expose the webhook server |
+
+#### Quick Deploy (Development)
+
+For development/testing without image tag pinning:
+
+```bash
+kubectl apply -k deploy/k8s
+```
+
+#### Production Deploy (with Immutable Image Tags)
+
+For production, pin to an immutable SHA tag to enable reliable rollbacks:
+
+```bash
+# Get the short SHA of the commit you want to deploy
+export SHORT_SHA=$(git rev-parse --short HEAD)
+
+# Build and apply with the specific image tag
+cd deploy/k8s
+kustomize edit set image ghcr.io/anthony-bible/code-agent-demo:sha-${SHORT_SHA}
+kustomize build . | kubectl apply -f -
+```
+
+This generates a manifest where the image tag is pinned to `sha-a1b2c3d` (or your specific commit SHA), making rollbacks predictable.
+
+#### Deployment from CI Image
+
+After CI builds and pushes an image, deploy the specific SHA tag:
+
+```bash
+# List available tags from GHCR
+gh api repos/Anthony-Bible/code-agent-demo/packages/container/code-agent-demo/versions
+
+# Deploy with the specific SHA tag
+cd deploy/k8s
+kustomize edit set image ghcr.io/anthony-bible/code-agent-demo:sha-<commit>
+kustomize build . | kubectl apply -f -
+```
+
+#### Verify Deployment
+
+```bash
+# Check pod status
+kubectl get pods -n code-agent
+
+# View logs
+kubectl logs -n code-agent -l app.kubernetes.io/name=code-agent-demo -f
+
+# Test health endpoint
+kubectl port-forward -n code-agent svc/code-agent-demo 8080:8080
+curl http://localhost:8080/health
+```
+
+#### Alert Sources Configuration
+
+The alert sources are configured via the `code-agent-alert-sources` ConfigMap. To update alert sources without redeploying:
+
+```bash
+# Edit the ConfigMap directly
+kubectl edit configmap -n code-agent code-agent-alert-sources
+
+# Or apply an updated file
+kubectl apply -f deploy/k8s/configmap-alert-sources.yaml
+
+# Restart the pod to pick up changes (if needed)
+kubectl rollout restart deployment -n code-agent code-agent-demo
+```
+
+#### Rollback
+
+To rollback to a previous version:
+
+```bash
+# Rollback using kubectl history
+kubectl rollout history deployment -n code-agent code-agent-demo
+kubectl rollout undo deployment -n code-agent code-agent-demo
+
+# Or redeploy with a previous SHA tag
+cd deploy/k8s
+kustomize edit set image ghcr.io/anthony-bible/code-agent-demo:sha-<previous-commit>
+kustomize build . | kubectl apply -f -
+```
+
+#### Security Considerations
+
+The deployment includes several security hardening measures:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `automountServiceAccountToken` | `false` | Disables implicit RBAC access |
+| ` readOnlyRootFilesystem` | `true` | Prevents in-place modifications |
+| `capabilities.drop` | `["ALL"]` | Removes all Linux capabilities |
+| `runAsNonRoot` | `true` | Enforces non-root user |
+| `runAsUser` / `runAsGroup` | `10001` | Specific non-privileged UID/GID |
+| `seccompProfile.type` | `RuntimeDefault` | Enables seccomp filtering |
+
+**Note**: Secrets (like API keys) should be stored in Kubernetes Secrets, not ConfigMaps. Create a secret if needed:
+
+```bash
+kubectl create secret generic -n code-agent code-agent-secrets \
+  --from-literal=ANTHROPIC_API_KEY=your-key-here
 ```
 
 ### Configuration

--- a/deploy/k8s/configmap-alert-sources.yaml
+++ b/deploy/k8s/configmap-alert-sources.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: code-agent-alert-sources
+  namespace: code-agent
+  labels:
+    app.kubernetes.io/name: code-agent-demo
+data:
+  alert-sources.yaml: |
+    # Alert Sources Configuration
+    # This file configures alert sources for the webhook server.
+
+    # Server address (optional, default: ":8080")
+    addr: ":8080"
+
+    # Alert sources to register
+    # Alert sources to register. Customize webhook_path values to match your Alertmanager/GCP
+    # notification configuration. The webhook_path must match what your alert sources POST to.
+    sources:
+      # Prometheus Alertmanager webhook
+      - type: prometheus
+        name: prometheus-prod
+        webhook_path: /alerts/prometheus
+
+      # Google Cloud Monitoring webhook source
+      - type: gcp_monitoring
+        name: gcp-alerts
+        webhook_path: /alerts/gcp

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: code-agent-config
+  namespace: code-agent
+  labels:
+    app.kubernetes.io/name: code-agent-demo
+data:
+  AGENT_MODEL: "hf:zai-org/GLM-4.7"
+  AGENT_MAX_TOKENS: "20000"
+  AGENT_WORKING_DIR: "/app"
+  AGENT_SAFETY_COMMAND_VALIDATION_MODE: "blacklist"
+  AGENT_SAFETY_AUTO_APPROVE_SAFE: "false"
+  AGENT_COMPACTION_THRESHOLD: "160000"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: code-agent-demo
+  namespace: code-agent
+  labels:
+    app.kubernetes.io/name: code-agent-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: code-agent-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: code-agent-demo
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: code-agent-demo
+          image: ghcr.io/anthony-bible/code-agent-demo:latest  # Image tag pinned via `kustomize edit set image` at deploy time
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: code-agent-config
+            - secretRef:
+                name: code-agent-secrets
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: agent-data
+              mountPath: /app/.agent
+            - name: alert-sources-config
+              mountPath: /app/config/alert-sources.yaml
+              subPath: alert-sources.yaml
+              readOnly: true
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: agent-data
+          emptyDir: {}
+        - name: alert-sources-config
+          configMap:
+            name: code-agent-alert-sources

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: code-agent
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - configmap-alert-sources.yaml
+  - deployment.yaml
+  - service.yaml
+
+images:
+  - name: ghcr.io/anthony-bible/code-agent-demo
+    newTag: latest  # Override with `kustomize edit set image` at deploy time

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-agent
+  labels:
+    app.kubernetes.io/name: code-agent-demo
+    app.kubernetes.io/part-of: code-agent

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: code-agent-demo
+  namespace: code-agent
+  labels:
+    app.kubernetes.io/name: code-agent-demo
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: code-agent-demo


### PR DESCRIPTION
… manifests

Add CI workflow (tests + build/push), multi-stage Dockerfile with .dockerignore, and Kubernetes manifests (namespace, configmap, deployment, service) for cluster deployment.