### PR TITLE
fix(investigation): unblock bash commands in headless webhook mode

### DIFF
--- a/internal/application/service/safety_enforcer.go
+++ b/internal/application/service/safety_enforcer.go
@@ -77,7 +77,7 @@ func (e *InvestigationSafetyEnforcer) CheckToolAllowed(tool string) error {
 // Uses the configured CommandValidator for whitelist/blacklist validation.
 func (e *InvestigationSafetyEnforcer) CheckCommandAllowed(cmd string) error {
 	result := e.validator.Validate(cmd, false)
-	if !result.Allowed {
+	if !result.Allowed || result.NeedsConfirm {
 		return ErrCommandBlocked
 	}
 	return nil

--- a/internal/application/service/safety_enforcer_test.go
+++ b/internal/application/service/safety_enforcer_test.go
@@ -12,16 +12,25 @@ import (
 
 // mockValidator is a test double for safety.CommandValidator.
 type mockValidator struct {
-	allowAll bool
-	blocked  map[string]bool
+	allowAll     bool
+	blocked      map[string]bool
+	needsConfirm map[string]bool
 }
 
 func newMockValidator(allowAll bool) *mockValidator {
-	return &mockValidator{allowAll: allowAll, blocked: make(map[string]bool)}
+	return &mockValidator{
+		allowAll:     allowAll,
+		blocked:      make(map[string]bool),
+		needsConfirm: make(map[string]bool),
+	}
 }
 
 func (m *mockValidator) blockCommand(cmd string) {
 	m.blocked[cmd] = true
+}
+
+func (m *mockValidator) requireConfirm(cmd string) {
+	m.needsConfirm[cmd] = true
 }
 
 func (m *mockValidator) Validate(command string, _ bool) safety.ValidationResult {
@@ -30,6 +39,14 @@ func (m *mockValidator) Validate(command string, _ bool) safety.ValidationResult
 			Allowed:     false,
 			IsDangerous: true,
 			Reason:      "blocked by mock",
+		}
+	}
+	if m.needsConfirm[command] {
+		return safety.ValidationResult{
+			Allowed:      true,
+			IsDangerous:  true,
+			Reason:       "requires confirmation",
+			NeedsConfirm: true,
 		}
 	}
 	if m.allowAll {
@@ -312,6 +329,48 @@ func TestInvestigationSafetyEnforcer_CheckCommandAllowed_EmptyCommand(t *testing
 	err := enforcer.CheckCommandAllowed("")
 	if err != nil {
 		t.Errorf("CheckCommandAllowed('') error = %v, want nil", err)
+	}
+}
+
+func TestInvestigationSafetyEnforcer_CheckCommandAllowed_NeedsConfirm(t *testing.T) {
+	cfg := config.DefaultInvestigationConfig()
+	validator := newMockValidator(true)
+	validator.requireConfirm("sudo systemctl restart app")
+	enforcer, err := NewInvestigationSafetyEnforcerWithValidator(cfg, validator)
+	if err != nil {
+		t.Fatalf("NewInvestigationSafetyEnforcerWithValidator() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		command string
+		wantErr bool
+	}{
+		{
+			name:    "NeedsConfirm=true blocks command in headless mode",
+			command: "sudo systemctl restart app",
+			wantErr: true,
+		},
+		{
+			name:    "NeedsConfirm=false allows safe command",
+			command: "ls -la",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := enforcer.CheckCommandAllowed(tt.command)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("CheckCommandAllowed(%q) should return ErrCommandBlocked", tt.command)
+				} else if !errors.Is(err, ErrCommandBlocked) {
+					t.Errorf("CheckCommandAllowed(%q) error = %v, want ErrCommandBlocked", tt.command, err)
+				}
+			} else if err != nil {
+				t.Errorf("CheckCommandAllowed(%q) error = %v, want nil", tt.command, err)
+			}
+		})
 	}
 }
 

--- a/internal/domain/safety/command_whitelist.go
+++ b/internal/domain/safety/command_whitelist.go
@@ -63,6 +63,10 @@ type CommandWhitelist struct {
 // Used by all whitelist patterns to ensure proper command boundary matching.
 const cmdBoundary = `(\s|$)`
 
+// devNullRedirectRe matches output redirections to /dev/null with a word boundary,
+// preventing false matches like /dev/nullfoo or /dev/nullmalware.
+var devNullRedirectRe = regexp.MustCompile(`^>{1,2}\s*/dev/null\b`)
+
 // MustSimple creates a WhitelistPattern for a simple command.
 // Uses regexp.QuoteMeta to escape cmd, ensuring safe pattern compilation.
 // Panics on invalid pattern (should never happen with QuoteMeta).
@@ -123,15 +127,10 @@ func NewCommandWhitelist(patterns []WhitelistPattern) *CommandWhitelist {
 
 // isDevNullRedirect reports whether the '>' at position i in cmd redirects to /dev/null.
 // It handles >>/dev/null, >> /dev/null, >/dev/null, and > /dev/null.
+// The regex requires a word boundary after /dev/null to prevent matching paths
+// like /dev/nullfoo or /dev/nullmalware.
 func isDevNullRedirect(cmd string, i int) bool {
-	j := i + 1
-	if j < len(cmd) && cmd[j] == '>' {
-		j++
-	}
-	for j < len(cmd) && cmd[j] == ' ' {
-		j++
-	}
-	return strings.HasPrefix(cmd[j:], "/dev/null")
+	return devNullRedirectRe.MatchString(cmd[i:])
 }
 
 // containsOutputRedirection checks if a command contains unquoted output redirection operators.

--- a/internal/domain/safety/command_whitelist.go
+++ b/internal/domain/safety/command_whitelist.go
@@ -121,6 +121,19 @@ func NewCommandWhitelist(patterns []WhitelistPattern) *CommandWhitelist {
 	}
 }
 
+// isDevNullRedirect reports whether the '>' at position i in cmd redirects to /dev/null.
+// It handles >>/dev/null, >> /dev/null, >/dev/null, and > /dev/null.
+func isDevNullRedirect(cmd string, i int) bool {
+	j := i + 1
+	if j < len(cmd) && cmd[j] == '>' {
+		j++
+	}
+	for j < len(cmd) && cmd[j] == ' ' {
+		j++
+	}
+	return strings.HasPrefix(cmd[j:], "/dev/null")
+}
+
 // containsOutputRedirection checks if a command contains unquoted output redirection operators.
 // Detects: >, >>, 2>, 2>>, &>, &>>, n>, n>> (where n is any digit).
 // Does NOT block input redirections: <, <<, <<<.
@@ -164,6 +177,9 @@ func containsOutputRedirection(cmd string) bool {
 			// If preceded by '<', this is part of <<, <<<, or <> — not an output redirect
 			if i > 0 && cmd[i-1] == '<' {
 				continue
+			}
+			if isDevNullRedirect(cmd, i) {
+				continue // /dev/null discards output safely
 			}
 			// This is an output redirection (>, >>, n>, &>, etc.)
 			return true

--- a/internal/domain/safety/command_whitelist_test.go
+++ b/internal/domain/safety/command_whitelist_test.go
@@ -2048,22 +2048,22 @@ func TestCommandWhitelist_OutputRedirectionBlocked(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
-			name:        "stderr redirect",
-			command:     "echo hello 2> /dev/null",
+			name:        "stderr redirect to file",
+			command:     "echo hello 2> error.log",
 			wantAllowed: false,
 		},
 		{
-			name:        "stderr append",
+			name:        "stderr append to file",
 			command:     "echo hello 2>> errors.log",
 			wantAllowed: false,
 		},
 		{
-			name:        "stdout and stderr redirect",
+			name:        "stdout and stderr redirect to file",
 			command:     "cat file &> output.txt",
 			wantAllowed: false,
 		},
 		{
-			name:        "stdout and stderr append",
+			name:        "stdout and stderr append to file",
 			command:     "cat file &>> output.txt",
 			wantAllowed: false,
 		},
@@ -2071,6 +2071,38 @@ func TestCommandWhitelist_OutputRedirectionBlocked(t *testing.T) {
 			name:        "fd 3 redirect",
 			command:     "echo hello 3> fd3.txt",
 			wantAllowed: false,
+		},
+
+		// Allowed: redirections to /dev/null (safe stderr/stdout suppression)
+		{
+			name:        "stderr redirect to /dev/null with space",
+			command:     "echo hello 2> /dev/null",
+			wantAllowed: true,
+		},
+		{
+			name:        "stderr redirect no space to /dev/null",
+			command:     "echo hello 2>/dev/null",
+			wantAllowed: true,
+		},
+		{
+			name:        "stdout redirect to /dev/null",
+			command:     "cat file >/dev/null",
+			wantAllowed: true,
+		},
+		{
+			name:        "stdout append to /dev/null",
+			command:     "cat file >>/dev/null",
+			wantAllowed: true,
+		},
+		{
+			name:        "stdout and stderr to /dev/null",
+			command:     "echo hello &>/dev/null",
+			wantAllowed: true,
+		},
+		{
+			name:        "stdout redirect space to /dev/null",
+			command:     "cat file > /dev/null",
+			wantAllowed: true,
 		},
 
 		// Allowed: no redirections

--- a/internal/domain/safety/command_whitelist_test.go
+++ b/internal/domain/safety/command_whitelist_test.go
@@ -2104,6 +2104,11 @@ func TestCommandWhitelist_OutputRedirectionBlocked(t *testing.T) {
 			command:     "cat file > /dev/null",
 			wantAllowed: true,
 		},
+		{
+			name:        "redirect to /dev/nullfoo is not safe",
+			command:     "cat secrets > /dev/nullfoo",
+			wantAllowed: false,
+		},
 
 		// Allowed: no redirections
 		{

--- a/internal/infrastructure/config/container.go
+++ b/internal/infrastructure/config/container.go
@@ -171,7 +171,7 @@ func NewContainer(cfg *Config) (*Container, error) {
 	wireSkillDeactivationCallback(baseExecutor, convService)
 
 	// Step 3: Create investigation and alert handling components
-	investigationUseCase, alertSourceManager, webhookAdapter, err := createInvestigationComponents(
+	investigationUseCase, alertSourceManager, webhookAdapter, invBase, err := createInvestigationComponents(
 		cfg, convService, fileManager, skillManager, subagentManager, uiAdapter, aiAdapter,
 		validationMode, validationWhitelist, log,
 	)
@@ -183,6 +183,13 @@ func NewContainer(cfg *Config) (*Container, error) {
 	subagentUseCase := createSubagentComponents(
 		cfg, convService, toolExecutor, aiAdapter, baseExecutor, uiAdapter, subagentManager, log,
 	)
+
+	// Wire skill callbacks and subagent use case into the investigation executor.
+	// The subagentUseCase is created after createInvestigationComponents returns,
+	// so we wire it here once both are available.
+	wireSkillActivationCallback(invBase, convService)
+	wireSkillDeactivationCallback(invBase, convService)
+	invBase.SetSubagentUseCase(subagentUseCase)
 
 	return &Container{
 		config:               cfg,
@@ -216,17 +223,17 @@ func createInvestigationComponents(
 	validationMode safety.CommandValidationMode,
 	validationWhitelist *safety.CommandWhitelist,
 	log port.Logger,
-) (*usecase.AlertInvestigationUseCase, port.AlertSourceManager, *webhook.HTTPAdapter, error) {
+) (*usecase.AlertInvestigationUseCase, port.AlertSourceManager, *webhook.HTTPAdapter, *tool.ExecutorAdapter, error) {
 	// Create a dedicated executor for investigations with a headless confirmation callback.
 	// Investigations run in the background without a terminal, so the shared interactive
 	// executor's ConfirmBashCommand would block every command. This executor auto-approves
 	// safe commands and hard-blocks dangerous ones.
-	_, invToolExecutor, err := newConfiguredExecutor(
+	invBase, invToolExecutor, err := newConfiguredExecutor(
 		fileManager, skillManager, subagentManager, validationMode, validationWhitelist,
 		cfg.Safety.AskLLMOnUnknown, cfg.WorkingDir, log,
 	)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to configure investigation command validation: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to configure investigation command validation: %w", err)
 	}
 	invToolExecutor.SetCommandConfirmationCallback(
 		buildHeadlessCallback(uiAdapter, "[INVESTIGATION BLOCKED]", "[INVESTIGATION AUTO-APPROVED]"),
@@ -245,13 +252,13 @@ func createInvestigationComponents(
 	// Create command validator using the pre-built validation config
 	commandValidator, err := safety.NewCommandValidator(validationMode, validationWhitelist, cfg.Safety.AskLLMOnUnknown)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create command validator: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create command validator: %w", err)
 	}
 
 	// Create safety enforcer with command validator
 	safetyEnforcer, err := appsvc.NewInvestigationSafetyEnforcerWithValidator(safetyConfig, commandValidator)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create safety enforcer: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create safety enforcer: %w", err)
 	}
 
 	// Create use case with operational config only
@@ -291,7 +298,7 @@ func createInvestigationComponents(
 	storePath := filepath.Join(cfg.WorkingDir, ".agent", "investigations")
 	fileStore, err := investigation.NewFileInvestigationStore(storePath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	investigationUseCase.SetInvestigationStore(&investigationStoreAdapter{store: fileStore})
 
@@ -309,7 +316,7 @@ func createInvestigationComponents(
 	webhookAdapter := webhook.NewHTTPAdapter(alertSourceManager, webhook.DefaultConfig(), log)
 	webhookAdapter.SetAlertHandler(alertHandler.HandleEntityAlert)
 
-	return investigationUseCase, alertSourceManager, webhookAdapter, nil
+	return investigationUseCase, alertSourceManager, webhookAdapter, invBase, nil
 }
 
 // createSubagentComponents sets up the subagent runner and use case.

--- a/internal/infrastructure/config/container.go
+++ b/internal/infrastructure/config/container.go
@@ -122,42 +122,25 @@ func NewContainer(cfg *Config) (*Container, error) {
 
 	aiAdapter := ai.NewAnthropicAdapter(cfg.AIModel, cfg.MaxTokens, subagentManager)
 
-	// Create base executor and wrap with planning decorator
-	baseExecutor := tool.NewExecutorAdapter(fileManager, log)
-	baseExecutor.SetSkillManager(skillManager)
-	baseExecutor.SetSubagentManager(subagentManager)
-
 	// Build validation config once; both the executor and investigation validator consume it
 	validationMode, validationWhitelist, err := buildValidationConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build validation config: %w", err)
 	}
-	if err := baseExecutor.SetValidationMode(validationMode, validationWhitelist, cfg.Safety.AskLLMOnUnknown); err != nil {
+
+	// Create base executor and wrap with planning decorator
+	baseExecutor, toolExecutor, err := newConfiguredExecutor(
+		fileManager, skillManager, subagentManager, validationMode, validationWhitelist,
+		cfg.Safety.AskLLMOnUnknown, cfg.WorkingDir, log,
+	)
+	if err != nil {
 		return nil, fmt.Errorf("failed to configure command validation: %w", err)
 	}
 
-	toolExecutor := tool.NewPlanningExecutorAdapter(baseExecutor, fileManager, cfg.WorkingDir)
-
 	// Set up bash command confirmation callback
-	// Behavior depends on cfg.Safety.AutoApproveSafeCommands flag
 	if cfg.Safety.AutoApproveSafeCommands {
-		// Auto-approve safe commands, block dangerous ones (headless mode)
-		toolExecutor.SetCommandConfirmationCallback(
-			func(command string, isDangerous bool, reason string, description string) bool {
-				if isDangerous {
-					// Block dangerous commands in headless mode
-					_ = uiAdapter.DisplaySystemMessage(
-						"[BLOCKED] " + description + ": " + command + " (reason: " + reason + ")",
-					)
-					return false
-				}
-				// Log auto-approved command
-				_ = uiAdapter.DisplaySystemMessage("[AUTO-APPROVED] " + description + ": " + command)
-				return true // Auto-approve safe commands
-			},
-		)
+		toolExecutor.SetCommandConfirmationCallback(buildHeadlessCallback(uiAdapter, "[BLOCKED]", "[AUTO-APPROVED]"))
 	} else {
-		// Default behavior: prompt user before executing any bash command
 		toolExecutor.SetCommandConfirmationCallback(
 			func(command string, isDangerous bool, reason, description string) bool {
 				return uiAdapter.ConfirmBashCommand(command, isDangerous, reason, description)
@@ -189,7 +172,7 @@ func NewContainer(cfg *Config) (*Container, error) {
 
 	// Step 3: Create investigation and alert handling components
 	investigationUseCase, alertSourceManager, webhookAdapter, err := createInvestigationComponents(
-		cfg, convService, toolExecutor, skillManager, uiAdapter, aiAdapter,
+		cfg, convService, fileManager, skillManager, subagentManager, uiAdapter, aiAdapter,
 		validationMode, validationWhitelist, log,
 	)
 	if err != nil {
@@ -220,17 +203,35 @@ func NewContainer(cfg *Config) (*Container, error) {
 
 // createInvestigationComponents sets up the investigation framework including
 // the use case, alert handler, source manager, and webhook adapter.
+// It creates a dedicated tool executor for investigations with a headless callback
+// (auto-approve safe, hard-block dangerous) instead of sharing the interactive executor.
 func createInvestigationComponents(
 	cfg *Config,
 	convService *service.ConversationService,
-	toolExecutor port.ToolExecutor,
+	fileManager port.FileManager,
 	skillManager port.SkillManager,
+	subagentManager port.SubagentManager,
 	uiAdapter port.UserInterface,
 	aiAdapter port.AIProvider,
 	validationMode safety.CommandValidationMode,
 	validationWhitelist *safety.CommandWhitelist,
 	log port.Logger,
 ) (*usecase.AlertInvestigationUseCase, port.AlertSourceManager, *webhook.HTTPAdapter, error) {
+	// Create a dedicated executor for investigations with a headless confirmation callback.
+	// Investigations run in the background without a terminal, so the shared interactive
+	// executor's ConfirmBashCommand would block every command. This executor auto-approves
+	// safe commands and hard-blocks dangerous ones.
+	_, invToolExecutor, err := newConfiguredExecutor(
+		fileManager, skillManager, subagentManager, validationMode, validationWhitelist,
+		cfg.Safety.AskLLMOnUnknown, cfg.WorkingDir, log,
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to configure investigation command validation: %w", err)
+	}
+	invToolExecutor.SetCommandConfirmationCallback(
+		buildHeadlessCallback(uiAdapter, "[INVESTIGATION BLOCKED]", "[INVESTIGATION AUTO-APPROVED]"),
+	)
+
 	// Create safety config (single source of truth for safety settings)
 	safetyConfig := appconfig.DefaultInvestigationConfig()
 
@@ -267,7 +268,7 @@ func createInvestigationComponents(
 
 	// Wire core dependencies
 	investigationUseCase.SetConversationService(convService)
-	investigationUseCase.SetToolExecutor(toolExecutor)
+	investigationUseCase.SetToolExecutor(invToolExecutor)
 	investigationUseCase.SetSkillManager(skillManager)
 	investigationUseCase.SetUIAdapter(uiAdapter)
 	if reporter, ok := uiAdapter.(port.RCAReporter); ok {
@@ -506,6 +507,50 @@ func parseCustomPatterns(json string) ([]safety.WhitelistPattern, error) {
 		return nil, nil
 	}
 	return safety.ParseWhitelistPatternsJSON(json)
+}
+
+// newConfiguredExecutor creates a base ExecutorAdapter and a PlanningExecutorAdapter
+// wrapper with validation mode, skill manager, and subagent manager wired up.
+// Returns both so callers that need post-wiring (skill callbacks, subagent use case)
+// can retain a reference to the base executor.
+func newConfiguredExecutor(
+	fileManager port.FileManager,
+	skillManager port.SkillManager,
+	subagentManager port.SubagentManager,
+	validationMode safety.CommandValidationMode,
+	validationWhitelist *safety.CommandWhitelist,
+	askLLMOnUnknown bool,
+	workingDir string,
+	log port.Logger,
+) (*tool.ExecutorAdapter, *tool.PlanningExecutorAdapter, error) {
+	base := tool.NewExecutorAdapter(fileManager, log)
+	base.SetSkillManager(skillManager)
+	base.SetSubagentManager(subagentManager)
+	if err := base.SetValidationMode(validationMode, validationWhitelist, askLLMOnUnknown); err != nil {
+		return nil, nil, err
+	}
+	planning := tool.NewPlanningExecutorAdapter(base, fileManager, workingDir)
+	return base, planning, nil
+}
+
+// buildHeadlessCallback returns a CommandConfirmationCallback that auto-approves safe
+// commands and hard-blocks dangerous ones, logging each decision via uiAdapter.
+// blockedLabel and approvedLabel appear at the start of the log message
+// (e.g. "[BLOCKED]" / "[INVESTIGATION BLOCKED]").
+func buildHeadlessCallback(
+	uiAdapter port.UserInterface,
+	blockedLabel, approvedLabel string,
+) tool.CommandConfirmationCallback {
+	return func(command string, isDangerous bool, reason, description string) bool {
+		if isDangerous {
+			_ = uiAdapter.DisplaySystemMessage(
+				blockedLabel + " " + description + ": " + command + " (reason: " + reason + ")",
+			)
+			return false
+		}
+		_ = uiAdapter.DisplaySystemMessage(approvedLabel + " " + description + ": " + command)
+		return true
+	}
 }
 
 // wireSkillActivationCallback sets up the callback for skill activation.

--- a/internal/infrastructure/config/container.go
+++ b/internal/infrastructure/config/container.go
@@ -238,6 +238,13 @@ func createInvestigationComponents(
 	invToolExecutor.SetCommandConfirmationCallback(
 		buildHeadlessCallback(uiAdapter, "[INVESTIGATION BLOCKED]", "[INVESTIGATION AUTO-APPROVED]"),
 	)
+	// Explicitly deny plan mode in headless investigations. Without this callback,
+	// enter_plan_mode silently activates plan mode (nil == allow), which would cause
+	// bash and mutating tools to write plan files instead of executing — stalling the
+	// investigation with no terminal available to unblock it.
+	invToolExecutor.SetPlanModeConfirmCallback(func(_ string) bool {
+		return false
+	})
 
 	// Create safety config (single source of truth for safety settings)
 	safetyConfig := appconfig.DefaultInvestigationConfig()


### PR DESCRIPTION
Three fixes so webhook-triggered investigations can actually run bash:

- Dedicated executor for investigations with a headless callback (auto-approve safe, hard-block dangerous) instead of sharing the interactive executor whose ConfirmBashCommand blocks every command when there is no terminal.
- SafetyEnforcer.CheckCommandAllowed now also blocks when NeedsConfirm is true; in blacklist mode dangerous commands return Allowed=true, NeedsConfirm=true and were silently passing the enforcer.
- containsOutputRedirection allows >/dev/null and 2>/dev/null; these are safe stderr/stdout suppression patterns, not file writes.

Refactors: extract newConfiguredExecutor and buildHeadlessCallback helpers to eliminate the duplicate executor-setup and callback logic that existed between the interactive and investigation code paths.