### PR TITLE
fix(investigation): pass investigation ID to AI and fix tool executor…

### DIFF
--- a/internal/application/usecase/investigation_prompt_builder.go
+++ b/internal/application/usecase/investigation_prompt_builder.go
@@ -4,6 +4,7 @@ package usecase
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/anthony-bible/code-agent-demo/internal/domain/entity"
@@ -235,14 +236,7 @@ You are an intelligent systems investigator. Analyze the alert below and use the
 		for k := range labels {
 			keys = append(keys, k)
 		}
-		// Sort keys alphabetically
-		for i := 0; i < len(keys); i++ {
-			for j := i + 1; j < len(keys); j++ {
-				if keys[i] > keys[j] {
-					keys[i], keys[j] = keys[j], keys[i]
-				}
-			}
-		}
+		sort.Strings(keys)
 		for _, k := range keys {
 			fmt.Fprintf(&sb, "- `%s`: %s\n", k, labels[k])
 		}

--- a/internal/application/usecase/investigation_prompt_builder.go
+++ b/internal/application/usecase/investigation_prompt_builder.go
@@ -92,12 +92,13 @@ func GenerateSkillsHeader(skills []port.SkillInfo) string {
 // AlertView represents a lightweight alert structure for prompt building.
 // It contains only the fields needed to generate investigation prompts.
 type AlertView struct {
-	id          string            // Unique alert identifier
-	source      string            // Alert source system (e.g., "prometheus", "cloudwatch")
-	severity    string            // Alert severity level
-	title       string            // Human-readable alert title
-	description string            // Detailed alert description
-	labels      map[string]string // Key-value metadata labels
+	id              string            // Unique alert identifier
+	source          string            // Alert source system (e.g., "prometheus", "cloudwatch")
+	severity        string            // Alert severity level
+	title           string            // Human-readable alert title
+	description     string            // Detailed alert description
+	labels          map[string]string // Key-value metadata labels
+	investigationID string            // Investigation ID for this investigation session
 }
 
 // ID returns the unique alert identifier.
@@ -124,6 +125,9 @@ func (a *AlertView) IsCritical() bool { return a.severity == "critical" }
 
 // LabelValue returns the value of a specific label, or empty string if not found.
 func (a *AlertView) LabelValue(key string) string { return a.labels[key] }
+
+// InvestigationID returns the investigation ID associated with this alert view.
+func (a *AlertView) InvestigationID() string { return a.investigationID }
 
 // InvestigationPromptBuilder generates prompts for AI-driven alert investigation.
 // Each builder is specialized for a specific alert type and generates prompts
@@ -184,6 +188,13 @@ func (b *GenericPromptBuilder) BuildPrompt(
 You are an intelligent systems investigator. Analyze the alert below and use the available tools to determine the root cause.
 
 `)
+
+	// Investigation context section - provides the investigation ID the AI must use
+	if alert.InvestigationID() != "" {
+		sb.WriteString("## Investigation Context\n\n")
+		fmt.Fprintf(&sb, "- **Investigation ID**: %s\n", alert.InvestigationID())
+		sb.WriteString("- **IMPORTANT**: When calling investigation tools (complete_investigation, escalate_investigation, report_investigation), use this Investigation ID — NOT the Alert ID.\n\n")
+	}
 
 	// Tools section
 	sb.WriteString("## Available Tools\n\n")

--- a/internal/application/usecase/investigation_prompt_builder.go
+++ b/internal/application/usecase/investigation_prompt_builder.go
@@ -191,9 +191,10 @@ You are an intelligent systems investigator. Analyze the alert below and use the
 
 	// Investigation context section - provides the investigation ID the AI must use
 	if alert.InvestigationID() != "" {
+		sanitizedID := strings.NewReplacer("\n", "", "\r", "").Replace(alert.InvestigationID())
 		sb.WriteString("## Investigation Context\n\n")
-		fmt.Fprintf(&sb, "- **Investigation ID**: %s\n", alert.InvestigationID())
-		sb.WriteString("- **IMPORTANT**: When calling investigation tools (complete_investigation, escalate_investigation, report_investigation), use this Investigation ID — NOT the Alert ID.\n\n")
+		fmt.Fprintf(&sb, "- **investigation_id**: `%s`\n", sanitizedID)
+		sb.WriteString("- **IMPORTANT**: When calling investigation tools (complete_investigation, escalate_investigation, report_investigation), pass this value as `investigation_id` — NOT the Alert ID.\n\n")
 	}
 
 	// Tools section

--- a/internal/application/usecase/investigation_prompt_builder_test.go
+++ b/internal/application/usecase/investigation_prompt_builder_test.go
@@ -277,6 +277,62 @@ func TestGenericPromptBuilder_BuildPrompt_NilAlert(t *testing.T) {
 	}
 }
 
+func TestGenericPromptBuilder_BuildPrompt_IncludesInvestigationID(t *testing.T) {
+	builder := NewGenericPromptBuilder()
+	if builder == nil {
+		t.Skip("NewGenericPromptBuilder() returned nil")
+	}
+
+	alert := &AlertView{
+		id:              "alert-inv-001",
+		source:          "prometheus",
+		severity:        "warning",
+		title:           "Test Alert",
+		labels:          map[string]string{},
+		investigationID: "inv-abc-123",
+	}
+
+	prompt, err := builder.BuildPrompt(alert, createTestTools(), nil)
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	if !strings.Contains(prompt, "Investigation Context") {
+		t.Error("BuildPrompt() should contain 'Investigation Context' section when investigationID is set")
+	}
+	if !strings.Contains(prompt, "inv-abc-123") {
+		t.Error("BuildPrompt() should contain the investigation ID")
+	}
+	if !strings.Contains(prompt, "NOT the Alert ID") {
+		t.Error("BuildPrompt() should warn the AI not to use the alert ID")
+	}
+}
+
+func TestGenericPromptBuilder_BuildPrompt_OmitsInvestigationContextWhenEmpty(t *testing.T) {
+	builder := NewGenericPromptBuilder()
+	if builder == nil {
+		t.Skip("NewGenericPromptBuilder() returned nil")
+	}
+
+	alert := &AlertView{
+		id:       "alert-no-inv-001",
+		source:   "prometheus",
+		severity: "warning",
+		title:    "Test Alert",
+		labels:   map[string]string{},
+		// investigationID intentionally empty
+	}
+
+	prompt, err := builder.BuildPrompt(alert, createTestTools(), nil)
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	if strings.Contains(prompt, "Investigation Context") {
+		t.Error("BuildPrompt() should NOT contain 'Investigation Context' when investigationID is empty")
+	}
+}
+
 // =============================================================================
 // Prompt Builder Registry Tests
 // =============================================================================

--- a/internal/application/usecase/investigation_runner.go
+++ b/internal/application/usecase/investigation_runner.go
@@ -287,11 +287,7 @@ func (r *InvestigationRunner) Run(
 	rc.SessionID = sessionID
 	defer r.CleanupConversation(sessionID, investigationID, "investigation_id")
 
-	// Register investigation so tool executor can validate tool calls against it.
-	// Uses the same optional interface pattern as SessionCleaner.
-	if registrar, ok := r.ToolExecutor.(port.InvestigationRegistrar); ok {
-		registrar.RegisterInvestigation(investigationID)
-	}
+	defer r.registerInvestigation(investigationID)()
 
 	// Configure extended thinking mode if enabled
 	if r.config.ExtendedThinking {
@@ -376,6 +372,20 @@ func (r *InvestigationRunner) validateInputs(ctx context.Context, alert *AlertFo
 	return ctx.Err()
 }
 
+// registerInvestigation registers the investigation ID with the tool executor (if it implements
+// InvestigationRegistrar) and returns a cleanup function that deregisters it on all exit paths.
+// Call as: defer r.registerInvestigation(id)().
+func (r *InvestigationRunner) registerInvestigation(investigationID string) func() {
+	if registrar, ok := r.ToolExecutor.(port.InvestigationRegistrar); ok {
+		registrar.RegisterInvestigation(investigationID)
+	}
+	return func() {
+		if deregistrar, ok := r.ToolExecutor.(port.InvestigationDeregistrar); ok {
+			deregistrar.DeregisterInvestigation(investigationID)
+		}
+	}
+}
+
 func (r *InvestigationRunner) validationFailedResult(
 	invID string,
 	alert *AlertForInvestigation,
@@ -422,7 +432,7 @@ func (r *InvestigationRunner) sendInitialPrompt(rc *runContext) error {
 
 	// Send a minimal user message to trigger the investigation.
 	// Since the system prompt already contains all context, we only need
-	// basic alert identifiers here to start the conversation.
+	// the investigation ID and basic alert identifiers here to start the conversation.
 	userMessage := r.formatTriggerMessage(rc.alert, rc.investigationID)
 	if _, err := r.ConvService.AddUserMessage(rc.Ctx, rc.SessionID, userMessage); err != nil {
 		return err
@@ -446,8 +456,8 @@ func (r *InvestigationRunner) createAlertView(alert *AlertForInvestigation, inve
 }
 
 // formatTriggerMessage creates a minimal user message to trigger the investigation.
-// This message contains only the essential alert identifiers since the full context
-// is already provided in the system prompt.
+// This message contains only the investigation ID and essential alert identifiers since
+// the full context is already provided in the system prompt.
 func (r *InvestigationRunner) formatTriggerMessage(alert *AlertForInvestigation, investigationID string) string {
 	return fmt.Sprintf("Investigation ID: %s\nAlert ID: %s\nTitle: %s", investigationID, alert.ID(), alert.Title())
 }

--- a/internal/application/usecase/investigation_runner.go
+++ b/internal/application/usecase/investigation_runner.go
@@ -285,9 +285,11 @@ func (r *InvestigationRunner) Run(
 		return rc.failedResult(err), err
 	}
 	rc.SessionID = sessionID
+	// Defers run in LIFO order: deregister investigation runs before session cleanup.
+	// This is safe because CleanupConversation doesn't invoke investigation tools.
 	defer r.CleanupConversation(sessionID, investigationID, "investigation_id")
-
-	defer r.registerInvestigation(investigationID)()
+	cleanup := r.registerInvestigation(investigationID)
+	defer cleanup()
 
 	// Configure extended thinking mode if enabled
 	if r.config.ExtendedThinking {
@@ -431,8 +433,8 @@ func (r *InvestigationRunner) sendInitialPrompt(rc *runContext) error {
 	}
 
 	// Send a minimal user message to trigger the investigation.
-	// Since the system prompt already contains all context, we only need
-	// the investigation ID and basic alert identifiers here to start the conversation.
+	// The system prompt contains full context including the investigation ID.
+	// This trigger message reinforces the ID and alert identifiers to start the conversation.
 	userMessage := r.formatTriggerMessage(rc.alert, rc.investigationID)
 	if _, err := r.ConvService.AddUserMessage(rc.Ctx, rc.SessionID, userMessage); err != nil {
 		return err

--- a/internal/application/usecase/investigation_runner.go
+++ b/internal/application/usecase/investigation_runner.go
@@ -287,6 +287,12 @@ func (r *InvestigationRunner) Run(
 	rc.SessionID = sessionID
 	defer r.CleanupConversation(sessionID, investigationID, "investigation_id")
 
+	// Register investigation so tool executor can validate tool calls against it.
+	// Uses the same optional interface pattern as SessionCleaner.
+	if registrar, ok := r.ToolExecutor.(port.InvestigationRegistrar); ok {
+		registrar.RegisterInvestigation(investigationID)
+	}
+
 	// Configure extended thinking mode if enabled
 	if r.config.ExtendedThinking {
 		thinkingBudget := r.config.ThinkingBudget
@@ -383,8 +389,7 @@ func (r *InvestigationRunner) validationFailedResult(
 }
 
 func (r *InvestigationRunner) sendInitialPrompt(rc *runContext) error {
-	// Create alert view for prompt building
-	alertView := r.createAlertView(rc.alert)
+	alertView := r.createAlertView(rc.alert, rc.investigationID)
 
 	// Get available tools for this investigation
 	tools, err := r.getInvestigationTools()
@@ -418,7 +423,7 @@ func (r *InvestigationRunner) sendInitialPrompt(rc *runContext) error {
 	// Send a minimal user message to trigger the investigation.
 	// Since the system prompt already contains all context, we only need
 	// basic alert identifiers here to start the conversation.
-	userMessage := r.formatTriggerMessage(rc.alert)
+	userMessage := r.formatTriggerMessage(rc.alert, rc.investigationID)
 	if _, err := r.ConvService.AddUserMessage(rc.Ctx, rc.SessionID, userMessage); err != nil {
 		return err
 	}
@@ -427,22 +432,24 @@ func (r *InvestigationRunner) sendInitialPrompt(rc *runContext) error {
 }
 
 // createAlertView converts an AlertForInvestigation into an AlertView for prompt building.
-func (r *InvestigationRunner) createAlertView(alert *AlertForInvestigation) *AlertView {
+// The investigationID is embedded so the prompt builder can include it for the AI.
+func (r *InvestigationRunner) createAlertView(alert *AlertForInvestigation, investigationID string) *AlertView {
 	return &AlertView{
-		id:          alert.ID(),
-		source:      alert.Source(),
-		severity:    alert.Severity(),
-		title:       alert.Title(),
-		description: alert.Description(),
-		labels:      alert.Labels(),
+		id:              alert.ID(),
+		source:          alert.Source(),
+		severity:        alert.Severity(),
+		title:           alert.Title(),
+		description:     alert.Description(),
+		labels:          alert.Labels(),
+		investigationID: investigationID,
 	}
 }
 
 // formatTriggerMessage creates a minimal user message to trigger the investigation.
 // This message contains only the essential alert identifiers since the full context
 // is already provided in the system prompt.
-func (r *InvestigationRunner) formatTriggerMessage(alert *AlertForInvestigation) string {
-	return fmt.Sprintf("Alert ID: %s\nTitle: %s", alert.ID(), alert.Title())
+func (r *InvestigationRunner) formatTriggerMessage(alert *AlertForInvestigation, investigationID string) string {
+	return fmt.Sprintf("Investigation ID: %s\nAlert ID: %s\nTitle: %s", investigationID, alert.ID(), alert.Title())
 }
 
 // getInvestigationTools returns the filtered list of tools for investigation prompts.

--- a/internal/application/usecase/investigation_runner_test.go
+++ b/internal/application/usecase/investigation_runner_test.go
@@ -197,7 +197,8 @@ func (m *investigationRunnerConvServiceMock) GetThinkingMode(sessionID string) (
 	return m.getThinkingModeInfo, m.getThinkingModeError
 }
 
-// investigationRunnerToolExecutorMock implements port.ToolExecutor for testing.
+// investigationRunnerToolExecutorMock implements port.ToolExecutor and
+// port.InvestigationRegistrar for testing.
 type investigationRunnerToolExecutorMock struct {
 	mu sync.Mutex
 
@@ -210,6 +211,15 @@ type investigationRunnerToolExecutorMock struct {
 
 	// Tools configuration
 	registeredTools []entity.Tool
+
+	// RegisterInvestigation tracking (implements port.InvestigationRegistrar)
+	registerInvestigationCalls []string
+}
+
+func (m *investigationRunnerToolExecutorMock) RegisterInvestigation(investigationID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.registerInvestigationCalls = append(m.registerInvestigationCalls, investigationID)
 }
 
 func newInvestigationRunnerToolExecutorMock() *investigationRunnerToolExecutorMock {
@@ -382,6 +392,39 @@ func (h *investigationRunnerTestHarness) build() *InvestigationRunner {
 func (h *investigationRunnerTestHarness) run(alert *AlertForInvestigation, invID string) (*InvestigationResult, error) {
 	h.t.Helper()
 	return h.build().Run(context.Background(), alert, invID)
+}
+
+// =============================================================================
+// RegisterInvestigation Tests
+// =============================================================================
+
+func TestInvestigationRunner_RegistersInvestigationBeforeLoop(t *testing.T) {
+	h := newTestHarness(t)
+	_, err := h.run(createTestAlert("alert-reg-001", "warning", "Test Alert"), "inv-reg-001")
+	if err != nil {
+		t.Errorf("Run() error = %v, want nil", err)
+	}
+	h.toolExecutor.mu.Lock()
+	calls := h.toolExecutor.registerInvestigationCalls
+	h.toolExecutor.mu.Unlock()
+	if len(calls) != 1 {
+		t.Errorf("RegisterInvestigation() called %d times, want 1", len(calls))
+	}
+	if len(calls) > 0 && calls[0] != "inv-reg-001" {
+		t.Errorf("RegisterInvestigation() called with %q, want %q", calls[0], "inv-reg-001")
+	}
+}
+
+func TestInvestigationRunner_DoesNotRegisterOnValidationFailure(t *testing.T) {
+	h := newTestHarness(t)
+	// Pass an empty investigation ID — validateInputs returns an error before registration
+	_, _ = h.build().Run(context.Background(), createTestAlert("alert-reg-002", "warning", "Test Alert"), "")
+	h.toolExecutor.mu.Lock()
+	calls := h.toolExecutor.registerInvestigationCalls
+	h.toolExecutor.mu.Unlock()
+	if len(calls) != 0 {
+		t.Errorf("RegisterInvestigation() called %d times on validation failure, want 0", len(calls))
+	}
 }
 
 // =============================================================================

--- a/internal/application/usecase/investigation_runner_test.go
+++ b/internal/application/usecase/investigation_runner_test.go
@@ -197,8 +197,8 @@ func (m *investigationRunnerConvServiceMock) GetThinkingMode(sessionID string) (
 	return m.getThinkingModeInfo, m.getThinkingModeError
 }
 
-// investigationRunnerToolExecutorMock implements port.ToolExecutor and
-// port.InvestigationRegistrar for testing.
+// investigationRunnerToolExecutorMock implements port.ToolExecutor,
+// port.InvestigationRegistrar, and port.InvestigationDeregistrar for testing.
 type investigationRunnerToolExecutorMock struct {
 	mu sync.Mutex
 
@@ -214,12 +214,21 @@ type investigationRunnerToolExecutorMock struct {
 
 	// RegisterInvestigation tracking (implements port.InvestigationRegistrar)
 	registerInvestigationCalls []string
+
+	// DeregisterInvestigation tracking (implements port.InvestigationDeregistrar)
+	deregisterInvestigationCalls []string
 }
 
 func (m *investigationRunnerToolExecutorMock) RegisterInvestigation(investigationID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.registerInvestigationCalls = append(m.registerInvestigationCalls, investigationID)
+}
+
+func (m *investigationRunnerToolExecutorMock) DeregisterInvestigation(investigationID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deregisterInvestigationCalls = append(m.deregisterInvestigationCalls, investigationID)
 }
 
 func newInvestigationRunnerToolExecutorMock() *investigationRunnerToolExecutorMock {
@@ -424,6 +433,23 @@ func TestInvestigationRunner_DoesNotRegisterOnValidationFailure(t *testing.T) {
 	h.toolExecutor.mu.Unlock()
 	if len(calls) != 0 {
 		t.Errorf("RegisterInvestigation() called %d times on validation failure, want 0", len(calls))
+	}
+}
+
+func TestInvestigationRunner_DeregistersInvestigationAfterRun(t *testing.T) {
+	h := newTestHarness(t)
+	_, err := h.run(createTestAlert("alert-dereg-001", "warning", "Test Alert"), "inv-dereg-001")
+	if err != nil {
+		t.Errorf("Run() error = %v, want nil", err)
+	}
+	h.toolExecutor.mu.Lock()
+	calls := h.toolExecutor.deregisterInvestigationCalls
+	h.toolExecutor.mu.Unlock()
+	if len(calls) != 1 {
+		t.Errorf("DeregisterInvestigation() called %d times, want 1", len(calls))
+	}
+	if len(calls) > 0 && calls[0] != "inv-dereg-001" {
+		t.Errorf("DeregisterInvestigation() called with %q, want %q", calls[0], "inv-dereg-001")
 	}
 }
 

--- a/internal/domain/port/tool_executor.go
+++ b/internal/domain/port/tool_executor.go
@@ -42,3 +42,10 @@ type SessionCleaner interface {
 type InvestigationRegistrar interface {
 	RegisterInvestigation(investigationID string)
 }
+
+// InvestigationDeregistrar is an optional interface that ToolExecutor implementations
+// can implement to remove an investigation ID after the investigation loop ends.
+// Implementing this prevents unbounded map growth when many investigations run over time.
+type InvestigationDeregistrar interface {
+	DeregisterInvestigation(investigationID string)
+}

--- a/internal/domain/port/tool_executor.go
+++ b/internal/domain/port/tool_executor.go
@@ -35,3 +35,10 @@ type ToolExecutor interface {
 type SessionCleaner interface {
 	CleanupSession(sessionID string)
 }
+
+// InvestigationRegistrar is an optional interface that ToolExecutor implementations
+// can implement to register an investigation ID before the investigation loop begins.
+// This allows investigation tools to validate that they are called with a known ID.
+type InvestigationRegistrar interface {
+	RegisterInvestigation(investigationID string)
+}

--- a/internal/infrastructure/adapter/tool/executor_bash_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_bash_tools.go
@@ -34,8 +34,8 @@ const defaultBashTimeout = 30 * time.Second
 // registerBashTool registers the bash tool.
 func (a *ExecutorAdapter) registerBashTool() {
 	bashTool := entity.Tool{
-		ID:          "bash",
-		Name:        "bash",
+		ID:          toolNameBash,
+		Name:        toolNameBash,
 		Description: "Executes shell commands and returns stdout, stderr, and exit code. You MUST assess whether each command is dangerous and set the dangerous field accordingly. Dangerous commands require user confirmation.",
 		InputSchema: map[string]interface{}{
 			"type": "object",

--- a/internal/infrastructure/adapter/tool/executor_file_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_file_tools.go
@@ -70,8 +70,8 @@ func appendTruncationNotice(result *strings.Builder, scanner *bufio.Scanner, lin
 func (a *ExecutorAdapter) registerFileTools() {
 	// Register read_file tool
 	readFileTool := entity.Tool{
-		ID:          "read_file",
-		Name:        "read_file",
+		ID:          toolNameReadFile,
+		Name:        toolNameReadFile,
 		Description: "Reads the contents of a given relative file path, use this when you want to see what's inside a file. Do not use this with directory names.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
@@ -322,7 +322,7 @@ func (a *ExecutorAdapter) executeEditFile(input json.RawMessage) (string, error)
 	}
 
 	// Write the modified content directly to avoid []byte→string→[]byte round-trip
-	if err := os.WriteFile(path, newContent, info.Mode().Perm()); err != nil {
+	if err := os.WriteFile(path, newContent, info.Mode().Perm()); err != nil { //nolint:gosec // G703: path is validated by LocalFileManager before reaching this point
 		return "", a.wrapFileOperationError("Failed to write file", err)
 	}
 

--- a/internal/infrastructure/adapter/tool/executor_investigation_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_investigation_tools.go
@@ -211,15 +211,8 @@ func (a *ExecutorAdapter) checkAndSetInvestigationStatus(investigationID, newSta
 	a.investigationMu.Lock()
 	defer a.investigationMu.Unlock()
 
-	status, exists := a.investigationStates[investigationID]
-	if !exists {
+	if _, exists := a.investigationStates[investigationID]; !exists {
 		return fmt.Errorf("investigation_id %q not found. Use the investigation_id provided in the system prompt under 'Investigation Context', not the alert ID", investigationID)
-	}
-	if status == investigationStatusCompleted {
-		return errors.New("investigation already completed")
-	}
-	if status == investigationStatusEscalated {
-		return errors.New("investigation already escalated")
 	}
 	if newStatus == investigationStatusCompleted || newStatus == investigationStatusEscalated {
 		delete(a.investigationStates, investigationID)
@@ -239,13 +232,25 @@ func validateInvestigationID(id string) error {
 
 // requireInvestigationExists checks if an investigation exists and returns an error if not.
 func (a *ExecutorAdapter) requireInvestigationExists(investigationID string) error {
-	a.investigationMu.Lock()
-	_, exists := a.investigationStates[investigationID]
-	a.investigationMu.Unlock()
-	if !exists {
+	a.investigationMu.RLock()
+	defer a.investigationMu.RUnlock()
+	if _, exists := a.investigationStates[investigationID]; !exists {
 		return fmt.Errorf("investigation_id %q not found. Use the investigation_id provided in the system prompt under 'Investigation Context', not the alert ID", investigationID)
 	}
 	return nil
+}
+
+// DeregisterInvestigation removes an investigation ID from the state map.
+// It is idempotent: calling it on an unknown ID is safe and has no effect.
+// Intended to be called via defer after the investigation loop ends to prevent
+// unbounded map growth across many investigations.
+func (a *ExecutorAdapter) DeregisterInvestigation(investigationID string) {
+	if investigationID == "" || strings.TrimSpace(investigationID) == "" {
+		return
+	}
+	a.investigationMu.Lock()
+	defer a.investigationMu.Unlock()
+	delete(a.investigationStates, investigationID)
 }
 
 // marshalInvestigationOutput marshals the output map to JSON, optionally adding investigation_id.

--- a/internal/infrastructure/adapter/tool/executor_investigation_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_investigation_tools.go
@@ -389,14 +389,13 @@ func (a *ExecutorAdapter) executeReportInvestigation(ctx context.Context, input 
 
 	// Build output
 	output := map[string]any{
-		"status":           "reported",
-		"investigation_id": in.InvestigationID,
-		"message":          in.Message,
-		"reported_at":      time.Now().UTC().Format(time.RFC3339),
+		"status":      "reported",
+		"message":     in.Message,
+		"reported_at": time.Now().UTC().Format(time.RFC3339),
 	}
 	if in.Progress != nil {
 		output["progress"] = *in.Progress
 	}
 
-	return marshalInvestigationOutput(output, "")
+	return marshalInvestigationOutput(output, in.InvestigationID)
 }

--- a/internal/infrastructure/adapter/tool/executor_investigation_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_investigation_tools.go
@@ -60,7 +60,7 @@ func (a *ExecutorAdapter) registerCompleteInvestigationTool() {
 			"properties": map[string]any{
 				"investigation_id": map[string]any{
 					"type":        "string",
-					"description": "The ID of the investigation to complete",
+					"description": "The ID of the investigation. Use the investigation_id from the Investigation Context in the system prompt.",
 				},
 				"confidence": map[string]any{
 					"type":        "number",
@@ -113,7 +113,7 @@ func (a *ExecutorAdapter) registerEscalateInvestigationTool() {
 			"properties": map[string]any{
 				"investigation_id": map[string]any{
 					"type":        "string",
-					"description": "The ID of the investigation to escalate",
+					"description": "The ID of the investigation. Use the investigation_id from the Investigation Context in the system prompt.",
 				},
 				"reason": map[string]any{
 					"type":        "string",
@@ -157,7 +157,7 @@ func (a *ExecutorAdapter) registerReportInvestigationTool() {
 			"properties": map[string]any{
 				"investigation_id": map[string]any{
 					"type":        "string",
-					"description": "The ID of the investigation to report on",
+					"description": "The ID of the investigation. Use the investigation_id from the Investigation Context in the system prompt.",
 				},
 				"message": map[string]any{
 					"type":        "string",
@@ -200,9 +200,9 @@ func (a *ExecutorAdapter) RegisterInvestigation(investigationID string) {
 	}
 }
 
-// checkAndSetInvestigationStatus checks if an investigation can transition to newStatus.
-// Returns nil if the transition is allowed, or an error if already in a terminal state.
-// If investigationID is empty, the check is skipped.
+// checkAndSetInvestigationStatus atomically checks if an investigation can transition to
+// newStatus and performs the transition. Returns an error if the ID is unknown or already
+// in a terminal state. Deletes terminal-state entries to prevent unbounded map growth.
 func (a *ExecutorAdapter) checkAndSetInvestigationStatus(investigationID, newStatus string) error {
 	if investigationID == "" || strings.TrimSpace(investigationID) == "" {
 		return nil
@@ -211,15 +211,21 @@ func (a *ExecutorAdapter) checkAndSetInvestigationStatus(investigationID, newSta
 	a.investigationMu.Lock()
 	defer a.investigationMu.Unlock()
 
-	if status, exists := a.investigationStates[investigationID]; exists {
-		if status == investigationStatusCompleted {
-			return errors.New("investigation already completed")
-		}
-		if status == investigationStatusEscalated {
-			return errors.New("investigation already escalated")
-		}
+	status, exists := a.investigationStates[investigationID]
+	if !exists {
+		return fmt.Errorf("investigation_id %q not found. Use the investigation_id provided in the system prompt under 'Investigation Context', not the alert ID", investigationID)
 	}
-	a.investigationStates[investigationID] = newStatus
+	if status == investigationStatusCompleted {
+		return errors.New("investigation already completed")
+	}
+	if status == investigationStatusEscalated {
+		return errors.New("investigation already escalated")
+	}
+	if newStatus == investigationStatusCompleted || newStatus == investigationStatusEscalated {
+		delete(a.investigationStates, investigationID)
+	} else {
+		a.investigationStates[investigationID] = newStatus
+	}
 	return nil
 }
 
@@ -237,7 +243,7 @@ func (a *ExecutorAdapter) requireInvestigationExists(investigationID string) err
 	_, exists := a.investigationStates[investigationID]
 	a.investigationMu.Unlock()
 	if !exists {
-		return fmt.Errorf("investigation_id %q not found", investigationID)
+		return fmt.Errorf("investigation_id %q not found. Use the investigation_id provided in the system prompt under 'Investigation Context', not the alert ID", investigationID)
 	}
 	return nil
 }
@@ -266,10 +272,6 @@ func (a *ExecutorAdapter) executeCompleteInvestigation(ctx context.Context, inpu
 	}
 
 	if err := validateInvestigationID(in.InvestigationID); err != nil {
-		return "", err
-	}
-
-	if err := a.requireInvestigationExists(in.InvestigationID); err != nil {
 		return "", err
 	}
 
@@ -320,10 +322,6 @@ func (a *ExecutorAdapter) executeEscalateInvestigation(ctx context.Context, inpu
 		return "", err
 	}
 
-	if err := a.requireInvestigationExists(in.InvestigationID); err != nil {
-		return "", err
-	}
-
 	// Validate reason
 	if in.Reason == "" || strings.TrimSpace(in.Reason) == "" {
 		return "", errors.New("reason is required and cannot be empty")
@@ -340,13 +338,14 @@ func (a *ExecutorAdapter) executeEscalateInvestigation(ctx context.Context, inpu
 	}
 
 	// Build output
-	escalationID := fmt.Sprintf("esc-%s-%d", in.InvestigationID, time.Now().UnixNano())
+	now := time.Now()
+	escalationID := fmt.Sprintf("esc-%s-%d", in.InvestigationID, now.UnixNano())
 	output := map[string]any{
 		"status":        investigationStatusEscalated,
 		"escalation_id": escalationID,
 		"reason":        in.Reason,
 		"priority":      in.Priority,
-		"escalated_at":  time.Now().UTC().Format(time.RFC3339),
+		"escalated_at":  now.UTC().Format(time.RFC3339),
 	}
 
 	return marshalInvestigationOutput(output, in.InvestigationID)

--- a/internal/infrastructure/adapter/tool/executor_plan_batch_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_plan_batch_tools.go
@@ -95,8 +95,8 @@ In plan mode, you will:
 
 	// Register batch_tool
 	batchToolTool := entity.Tool{
-		ID:   "batch_tool",
-		Name: "batch_tool",
+		ID:   toolNameBatchTool,
+		Name: toolNameBatchTool,
 		Description: `Execute multiple tool invocations in a single batch operation. Prefer this when running multiple tools.
 
 Use this tool when you need to:
@@ -290,7 +290,7 @@ func (a *ExecutorAdapter) executeSingleBatchInvocation(
 	}
 
 	// Check for nested batch_tool invocations
-	if inv.ToolName == "batch_tool" {
+	if inv.ToolName == toolNameBatchTool {
 		result.Success = false
 		result.Error = "nested batch_tool invocations are not allowed"
 		result.DurationMs = 0

--- a/internal/infrastructure/adapter/tool/investigation_tools_test.go
+++ b/internal/infrastructure/adapter/tool/investigation_tools_test.go
@@ -460,9 +460,7 @@ func TestInvestigationTool_RejectsAlreadyProcessedInvestigation(t *testing.T) {
 				t.Error("Expected error when processing already-processed investigation, got nil")
 			}
 
-			if err != nil && !strings.Contains(strings.ToLower(err.Error()), "already") {
-				t.Errorf("Expected error to mention 'already', got: %v", err)
-			}
+			// Error message varies ("already completed", "not found") — contract is rejection.
 		})
 	}
 }

--- a/internal/infrastructure/adapter/tool/investigation_tools_test.go
+++ b/internal/infrastructure/adapter/tool/investigation_tools_test.go
@@ -1969,3 +1969,49 @@ func TestReportInvestigationTool_ToolDescription(t *testing.T) {
 		t.Error("Description should mention report, progress, or status")
 	}
 }
+
+// =============================================================================
+// DeregisterInvestigation Tests
+// =============================================================================
+
+func TestDeregisterInvestigation_AfterRegister_ToolCallFails(t *testing.T) {
+	h := newInvestigationTestHelper(t)
+	invID := "deregister-test-001"
+	h.adapter.RegisterInvestigation(invID)
+
+	// Verify it works before deregistration
+	input, _ := json.Marshal(map[string]interface{}{
+		"investigation_id": invID,
+		"confidence":       0.9,
+		"findings":         []interface{}{"test finding"},
+	})
+	// Use report_investigation to check existence without consuming the entry
+	reportInput, _ := json.Marshal(map[string]interface{}{
+		"investigation_id": invID,
+		"message":          "progress check",
+	})
+	_, err := h.adapter.ExecuteTool(context.Background(), "report_investigation", string(reportInput))
+	if err != nil {
+		t.Fatalf("report_investigation before deregister should succeed, got: %v", err)
+	}
+
+	h.adapter.DeregisterInvestigation(invID)
+
+	// After deregistration, any tool call referencing the ID should return "not found"
+	_, err = h.adapter.ExecuteTool(context.Background(), "complete_investigation", string(input))
+	if err == nil {
+		t.Error("complete_investigation after deregister should fail")
+	}
+	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "not found") {
+		t.Errorf("expected 'not found' error after deregister, got: %v", err)
+	}
+}
+
+func TestDeregisterInvestigation_NonExistentID_IsNoop(t *testing.T) {
+	h := newInvestigationTestHelper(t)
+
+	// Should not panic or error — just a no-op
+	h.adapter.DeregisterInvestigation("does-not-exist-xyz")
+	h.adapter.DeregisterInvestigation("")
+	h.adapter.DeregisterInvestigation("   ")
+}

--- a/internal/infrastructure/adapter/tool/planning_executor_adapter.go
+++ b/internal/infrastructure/adapter/tool/planning_executor_adapter.go
@@ -112,8 +112,8 @@ func (p *PlanningExecutorAdapter) ValidateToolInput(name string, input interface
 // isReadOnlyTool returns true if the tool is read-only and should always execute.
 func isReadOnlyTool(name string) bool {
 	readOnlyTools := map[string]bool{
-		"read_file":  true,
-		"list_files": true,
+		toolNameReadFile: true,
+		"list_files":     true,
 	}
 	return readOnlyTools[name]
 }

--- a/internal/infrastructure/adapter/tool/tool_executor_adapter.go
+++ b/internal/infrastructure/adapter/tool/tool_executor_adapter.go
@@ -16,6 +16,13 @@ import (
 	fileadapter "github.com/anthony-bible/code-agent-demo/internal/infrastructure/adapter/file"
 )
 
+// Tool name constants used across multiple files in this package.
+const (
+	toolNameReadFile  = "read_file"
+	toolNameBash      = "bash"
+	toolNameBatchTool = "batch_tool"
+)
+
 // SubagentUseCaseInterface defines the interface for spawning subagents.
 //
 // This interface enables the task tool to delegate work to specialized subagents,
@@ -64,7 +71,7 @@ type ExecutorAdapter struct {
 	skillActivationCallback     SkillActivationCallback
 	skillDeactivationCallback   SkillDeactivationCallback
 	investigationStates         map[string]string // tracks investigation_id -> status
-	investigationMu             sync.Mutex
+	investigationMu             sync.RWMutex
 
 	fetchClient     *http.Client
 	fetchClientOnce sync.Once
@@ -357,13 +364,13 @@ func (a *ExecutorAdapter) registerDefaultTools() {
 // executeByName executes the appropriate tool function based on the tool name.
 func (a *ExecutorAdapter) executeByName(ctx context.Context, name string, input json.RawMessage) (string, error) {
 	switch name {
-	case "read_file":
+	case toolNameReadFile:
 		return a.executeReadFile(input)
 	case "list_files":
 		return a.executeListFiles(input)
 	case "edit_file":
 		return a.executeEditFile(input)
-	case "bash":
+	case toolNameBash:
 		return a.executeBash(ctx, input)
 	case "fetch":
 		return a.executeFetch(ctx, input)
@@ -371,7 +378,7 @@ func (a *ExecutorAdapter) executeByName(ctx context.Context, name string, input 
 		return a.executeActivateSkill(ctx, input)
 	case "deactivate_skill":
 		return a.executeDeactivateSkill(ctx, input)
-	case "batch_tool":
+	case toolNameBatchTool:
 		return a.executeBatchTool(ctx, input)
 	case "task":
 		return a.executeTask(ctx, input)


### PR DESCRIPTION
… concurrency

- Embed investigationID in AlertView and include it in the system prompt under an "Investigation Context" section so the AI uses the correct ID when calling investigation tools (not the alert ID)
- Add InvestigationRegistrar optional interface; InvestigationRunner registers the ID before the loop so tools can validate calls
- Fix TOCTOU race: collapse requireInvestigationExists pre-check into checkAndSetInvestigationStatus as a single atomic lock operation
- Fix unbounded investigationStates map growth: delete entries on terminal state (complete/escalate) rather than accumulating forever
- Fix time.Now() called twice in executeEscalateInvestigation
- Update duplicate-rejection test to check contract (second call fails) rather than specific error message text