### PR TITLE
feat(serve): wire Genkit provider with cache warmup + readiness gating (3/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ logs/*.log
 
 # Code review files
 REVIEW-*.md
+
+# Local environment / secrets
+.env
+.env.local
+.env.*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ Environment variables with `AGENT_` prefix:
 - `AGENT_SAFETY_ASK_LLM_ON_UNKNOWN` - Ask LLM before blocking non-whitelisted commands (default: `true`)
 - `AGENT_SAFETY_AUTO_APPROVE_SAFE` - Auto-approve non-dangerous bash commands without confirmation (default: `false`)
 - `AGENT_COMPACTION_THRESHOLD` - Token threshold for auto-compaction of conversation history (default: `160000`, minimum: `10000`)
+- `AGENT_AI_PROVIDER` - AI provider implementation: `anthropic` (default) or `genkit`
+- `AGENT_GENKIT_PLUGIN` - Genkit plugin name (default: `anthropic`; ignored when `AGENT_AI_PROVIDER != genkit`)
 
 ## Logging
 

--- a/cmd/cli/cmd/serve.go
+++ b/cmd/cli/cmd/serve.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/anthony-bible/code-agent-demo/internal/application/usecase"
 	"github.com/anthony-bible/code-agent-demo/internal/domain/port"
+	"github.com/anthony-bible/code-agent-demo/internal/infrastructure/adapter/ai"
 	"github.com/anthony-bible/code-agent-demo/internal/infrastructure/adapter/alert"
 	"github.com/anthony-bible/code-agent-demo/internal/infrastructure/adapter/webhook"
 	"github.com/anthony-bible/code-agent-demo/internal/infrastructure/config"
@@ -15,6 +16,29 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// runWarmup primes the AI provider's tool-schema cache by issuing a small
+// tool-bearing request. The first call after process boot can compile the
+// strict-mode grammar (~30-100s); subsequent calls hit Anthropic's 24h
+// regional cache. Runs async so /ready can flip from 503 → 200 once warmup
+// completes.
+//
+// On warmup failure we still call MarkWarm — a cold cache is a latency
+// penalty, not a correctness problem, and we'd rather serve traffic slowly
+// than wedge the pod in NotReady forever.
+func runWarmup(ctx context.Context, container *config.Container, adapter *webhook.HTTPAdapter, logger port.Logger) {
+	defer adapter.MarkWarm()
+
+	tools, err := ai.ToolParamsFromExecutor(container.ToolExecutor())
+	if err != nil {
+		logger.Warn("warmup: skipped — could not list tools", "error", err)
+		return
+	}
+
+	if err := ai.WarmCache(ctx, container.AIAdapter(), tools, logger); err != nil {
+		logger.Warn("warmup: failed (continuing anyway, first real request will pay the cache-miss cost)", "error", err)
+	}
+}
 
 // serveCmd represents the serve command.
 //
@@ -191,6 +215,31 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	// Credentials are applied after adapter creation so they are not logged.
 	// They are stored in the adapter's internal map and in the parsed config.
 	applyBasicAuth(webhookCfg, webhookAdapter, container.Logger())
+
+	// Gate readiness on cache warmup — /ready returns 503 until the goroutine
+	// below either succeeds or fails. We use a fresh background context (not
+	// the cancellable cmd context) so a fast Ctrl+C during boot still lets the
+	// in-flight warmup HTTP request finish cleanly under its own 3-minute
+	// timeout rather than tearing it midway.
+	//
+	// Only warm up when running under the Genkit provider: warmup exists to
+	// pre-seed Genkit's per-tool-schema prompt cache. AnthropicAdapter doesn't
+	// benefit and would otherwise pay an unintentional startup API call plus
+	// readiness delay.
+	if cfg.AIProvider == config.ProviderGenkit {
+		webhookAdapter.SetWarmupRequired(true)
+		// Derive a bounded context that we cancel when the server returns, so the
+		// warmup goroutine doesn't outlive a graceful shutdown (e.g., SIGTERM in
+		// Kubernetes) by up to WarmCacheTimeout. The timeout still bounds the
+		// worst-case wait so a fast Ctrl+C during boot doesn't tear the in-flight
+		// HTTP call midway — it gets its own deadline.
+		warmupCtx, warmupCancel := context.WithTimeout(context.Background(), ai.WarmCacheTimeout)
+		defer warmupCancel()
+		go runWarmup(warmupCtx, container, webhookAdapter, container.Logger())
+	} else {
+		container.Logger().Debug("warmup: skipped — provider does not require warmup",
+			"provider", cfg.AIProvider)
+	}
 
 	// Set up SIGHUP handler for skill hot-reload
 	reloadHandler := setupSkillReloadHandler(container)

--- a/internal/infrastructure/adapter/ai/genkit_adapter_e2e_test.go
+++ b/internal/infrastructure/adapter/ai/genkit_adapter_e2e_test.go
@@ -1,0 +1,373 @@
+//go:build e2e
+
+// Package ai — E2E tests for GenkitAdapter against the live Anthropic API.
+//
+// Run with:
+//
+//	source .env && go test -tags=e2e -v -run E2E ./internal/infrastructure/adapter/ai/... -timeout 120s
+//
+// Tests are skipped automatically when ANTHROPIC_API_KEY is unset.
+package ai
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anthony-bible/code-agent-demo/internal/domain/entity"
+	"github.com/anthony-bible/code-agent-demo/internal/domain/port"
+	"github.com/anthony-bible/code-agent-demo/internal/infrastructure/adapter/file"
+	"github.com/anthony-bible/code-agent-demo/internal/infrastructure/adapter/tool"
+)
+
+const (
+	e2eModel     = "claude-haiku-4-5"
+	e2eMaxTokens = int64(256)
+)
+
+// skipIfNoAPIKey skips the calling test if ANTHROPIC_API_KEY is unset or empty.
+func skipIfNoAPIKey(t *testing.T) {
+	t.Helper()
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Skip("ANTHROPIC_API_KEY not set; skipping live E2E test")
+	}
+}
+
+// newE2EAdapter builds a GenkitAdapter pointed at the live Anthropic API.
+// It fails the test (not skips) if construction itself fails, because that
+// indicates a code bug rather than a missing environment variable.
+func newE2EAdapter(t *testing.T) port.AIProvider {
+	t.Helper()
+	adapter, err := NewGenkitAdapter(e2eModel, e2eMaxTokens, nil, port.NopLogger{})
+	if err != nil {
+		t.Fatalf("NewGenkitAdapter construction failed: %v", err)
+	}
+	return adapter
+}
+
+// TestE2E_GenkitAdapter runs live Anthropic API tests against GenkitAdapter.
+func TestE2E_GenkitAdapter(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	// Sub-test 1: Plain SendMessage — single round-trip, no tools.
+	t.Run("SendMessage_Pong", func(t *testing.T) {
+		adapter := newE2EAdapter(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		msg, toolCalls, err := adapter.SendMessage(
+			ctx,
+			[]port.MessageParam{
+				{Role: entity.RoleUser, Content: "Reply with the single word: pong"},
+			},
+			nil,
+			port.AIRequestOptions{},
+		)
+		if err != nil {
+			t.Fatalf("SendMessage failed: %v", err)
+		}
+		if len(toolCalls) != 0 {
+			t.Errorf("expected no tool calls for plain text query; got %d", len(toolCalls))
+		}
+		if msg == nil {
+			t.Fatal("expected non-nil message")
+		}
+		if !strings.Contains(strings.ToLower(msg.Content), "pong") {
+			t.Errorf("response does not contain 'pong': %q", msg.Content)
+		}
+		t.Logf("sub-test 1 response: %q (in=%d out=%d)", msg.Content, msg.InputTokens, msg.OutputTokens)
+	})
+
+	// Sub-test 2: SendMessage with a tool — assert ToolCallInfo is returned.
+	// We send a message asking what time it is and give the model a get_time tool.
+	// We assert a ToolCallInfo for get_time is present; we do NOT drive the loop further
+	// because the domain layer owns that responsibility.
+	t.Run("SendMessage_WithTool", func(t *testing.T) {
+		adapter := newE2EAdapter(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		tools := []port.ToolParam{
+			{
+				Name:        "get_time",
+				Description: "Returns the current UTC time as an ISO 8601 timestamp.",
+				InputSchema: map[string]interface{}{
+					"type":       "object",
+					"properties": map[string]interface{}{},
+				},
+			},
+		}
+
+		msg, toolCalls, err := adapter.SendMessage(
+			ctx,
+			[]port.MessageParam{
+				{Role: entity.RoleUser, Content: "What is the current time? Use the get_time tool."},
+			},
+			tools,
+			port.AIRequestOptions{},
+		)
+		if err != nil {
+			t.Fatalf("SendMessage with tool failed: %v", err)
+		}
+		if msg == nil {
+			t.Fatal("expected non-nil message")
+		}
+		if len(toolCalls) == 0 {
+			t.Errorf("expected at least one ToolCallInfo for get_time; got none (response=%q)", msg.Content)
+		} else {
+			found := false
+			for _, tc := range toolCalls {
+				if tc.ToolName == "get_time" {
+					found = true
+					if tc.ToolID == "" {
+						t.Errorf("ToolCallInfo.ToolID should be non-empty")
+					}
+					t.Logf("sub-test 2 tool call: id=%q name=%q input=%v", tc.ToolID, tc.ToolName, tc.Input)
+				}
+			}
+			if !found {
+				t.Errorf("tool calls present but none for 'get_time': %+v", toolCalls)
+			}
+		}
+	})
+
+	// Sub-test 3: SendMessageStreaming — same "pong" prompt, verify streaming callback fires
+	// and the final accumulated result also contains "pong".
+	t.Run("SendMessageStreaming_Pong", func(t *testing.T) {
+		adapter := newE2EAdapter(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		var accumulated strings.Builder
+		callbackCount := 0
+
+		textCallback := func(chunk string) error {
+			accumulated.WriteString(chunk)
+			callbackCount++
+			return nil
+		}
+
+		msg, toolCalls, err := adapter.SendMessageStreaming(
+			ctx,
+			[]port.MessageParam{
+				{Role: entity.RoleUser, Content: "Reply with the single word: pong"},
+			},
+			nil,
+			port.AIRequestOptions{},
+			textCallback,
+			nil, // no thinking callback
+		)
+		if err != nil {
+			t.Fatalf("SendMessageStreaming failed: %v", err)
+		}
+		if len(toolCalls) != 0 {
+			t.Errorf("expected no tool calls for plain text query; got %d", len(toolCalls))
+		}
+		if msg == nil {
+			t.Fatal("expected non-nil final message from streaming")
+		}
+		// The streaming callback should have fired at least once.
+		if callbackCount == 0 {
+			t.Errorf("textCallback was never invoked; streaming may not be working")
+		}
+		// The accumulated text from callbacks should be non-empty and contain "pong".
+		accText := accumulated.String()
+		if accText == "" {
+			t.Errorf("accumulated streaming text is empty")
+		}
+		if !strings.Contains(strings.ToLower(accText), "pong") {
+			t.Errorf("accumulated streaming text does not contain 'pong': %q", accText)
+		}
+		// The returned message should also contain "pong".
+		if !strings.Contains(strings.ToLower(msg.Content), "pong") {
+			t.Errorf("final message content does not contain 'pong': %q", msg.Content)
+		}
+		t.Logf("sub-test 3: %d chunks, accumulated=%q, final=%q", callbackCount, accText, msg.Content)
+	})
+
+	// Sub-test 4 (optional): Extended thinking — simple math question with budget=1024.
+	// If the Genkit Anthropic plugin returns an error for thinking with haiku-4-5
+	// (e.g. model does not support thinking), we skip with a clear reason rather than
+	// failing, since the model may not support extended thinking.
+	t.Run("SendMessage_ExtendedThinking", func(t *testing.T) {
+		// Extended thinking requires a larger max_tokens value than the default e2eMaxTokens.
+		// The minimum for thinking is budget_tokens + at least some output tokens.
+		// Use a dedicated adapter with higher token limit for this sub-test.
+		adapter, err := NewGenkitAdapter(e2eModel, int64(2048), nil, port.NopLogger{})
+		if err != nil {
+			t.Fatalf("NewGenkitAdapter failed: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+		defer cancel()
+
+		opts := port.AIRequestOptions{
+			Thinking: &port.ThinkingModeInfo{
+				Enabled:      true,
+				BudgetTokens: int64(1024),
+			},
+		}
+
+		msg, _, err := adapter.SendMessage(
+			ctx,
+			[]port.MessageParam{
+				{Role: entity.RoleUser, Content: "What is 17 multiplied by 23? Think through it step by step."},
+			},
+			nil,
+			opts,
+		)
+		if err != nil {
+			// Some models or API configurations may not support extended thinking.
+			// Treat this as a skip rather than a hard failure so the CI doesn't
+			// block on a capability gap in the chosen model.
+			t.Skipf("extended thinking returned error (model may not support it): %v", err)
+		}
+		if msg == nil {
+			t.Fatal("expected non-nil message")
+		}
+		// We expect thinking blocks to be present when thinking is enabled.
+		if len(msg.ThinkingBlocks) == 0 {
+			t.Errorf("expected at least one thinking block with extended thinking enabled; got none (content=%q)", msg.Content)
+		} else {
+			preview := msg.ThinkingBlocks[0].Thinking
+			if len(preview) > 80 {
+				preview = preview[:80]
+			}
+			t.Logf("sub-test 4: %d thinking block(s), first thinking=%q",
+				len(msg.ThinkingBlocks), preview)
+		}
+		// The final answer should reference 391 (17*23).
+		if !strings.Contains(msg.Content, "391") {
+			t.Errorf("expected answer 391 in response; got: %q", msg.Content)
+		}
+		t.Logf("sub-test 4 content: %q", msg.Content)
+	})
+
+	// Sub-test 5: SendMessage with the full tool catalog registered in one call.
+	// Verifies that per-tool WithStrict(false) registration, name sanitization,
+	// and the bidirectional name map all hold up when many tools are presented
+	// simultaneously. Asserts the model picked exactly one tool and that the
+	// reported ToolName is the original (un-sanitized) port name.
+	t.Run("SendMessage_AllToolsAtOnce", func(t *testing.T) {
+		t.Parallel()
+		adapter := newE2EAdapter(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		// Source the real tool catalog from the project's ExecutorAdapter so this
+		// stays in sync with whatever tools the agent actually exposes.
+		fm := file.NewLocalFileManager(t.TempDir())
+		exec := tool.NewExecutorAdapter(fm, port.NopLogger{})
+		entityTools, err := exec.ListTools()
+		if err != nil {
+			t.Fatalf("ListTools failed: %v", err)
+		}
+		if len(entityTools) < 10 {
+			t.Fatalf("expected the executor to expose the full tool catalog (>= 10); got %d", len(entityTools))
+		}
+
+		tools := make([]port.ToolParam, 0, len(entityTools))
+		known := make(map[string]bool, len(entityTools))
+		for _, et := range entityTools {
+			tools = append(tools, port.ToolParam{
+				Name:        et.Name,
+				Description: et.Description,
+				InputSchema: et.InputSchema,
+				Strict:      et.Strict,
+			})
+			known[et.Name] = true
+		}
+		t.Logf("sub-test 5: registering %d tools: %v", len(tools), toolNames(entityTools))
+
+		msg, toolCalls, err := adapter.SendMessage(
+			ctx,
+			[]port.MessageParam{
+				{Role: entity.RoleUser, Content: "List the files in the current directory using the available tools."},
+			},
+			tools,
+			port.AIRequestOptions{},
+		)
+		if err != nil {
+			t.Fatalf("SendMessage with full tool catalog failed: %v", err)
+		}
+		if msg == nil {
+			t.Fatal("expected non-nil message")
+		}
+		if len(toolCalls) == 0 {
+			t.Fatalf("expected at least one ToolCallInfo; got none (response=%q)", msg.Content)
+		}
+
+		var picked []string
+		for _, tc := range toolCalls {
+			if !known[tc.ToolName] {
+				t.Errorf("ToolCallInfo.ToolName %q is not one of the originally registered names %v",
+					tc.ToolName, known)
+			}
+			if tc.ToolID == "" {
+				t.Errorf("ToolCallInfo.ToolID should be non-empty for %q", tc.ToolName)
+			}
+			picked = append(picked, tc.ToolName)
+		}
+		t.Logf("sub-test 5: model picked tools %v from a catalog of %d", picked, len(tools))
+	})
+
+	// Sub-test 6: parity check — same full tool catalog through the raw
+	// AnthropicAdapter. Lets us answer "but doesn't it work on the regular SDK?"
+	// empirically rather than by reading docs.
+	t.Run("SendMessage_AllToolsAtOnce_RawAnthropic", func(t *testing.T) {
+		t.Parallel()
+		// Defensive: the outer TestE2E_GenkitAdapter already skips on missing
+		// key, but adding this here makes the sub-test self-contained against
+		// future extraction into a top-level test.
+		skipIfNoAPIKey(t)
+		anth := NewAnthropicAdapter(e2eModel, e2eMaxTokens, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		fm := file.NewLocalFileManager(t.TempDir())
+		exec := tool.NewExecutorAdapter(fm, port.NopLogger{})
+		entityTools, err := exec.ListTools()
+		if err != nil {
+			t.Fatalf("ListTools failed: %v", err)
+		}
+		tools := make([]port.ToolParam, 0, len(entityTools))
+		for _, et := range entityTools {
+			tools = append(tools, port.ToolParam{
+				Name:        et.Name,
+				Description: et.Description,
+				InputSchema: et.InputSchema,
+				Strict:      et.Strict,
+			})
+		}
+		t.Logf("sub-test 6: AnthropicAdapter registering %d tools: %v",
+			len(tools), toolNames(entityTools))
+
+		msg, toolCalls, err := anth.SendMessage(
+			ctx,
+			[]port.MessageParam{
+				{Role: entity.RoleUser, Content: "List the files in the current directory using the available tools."},
+			},
+			tools,
+			port.AIRequestOptions{},
+		)
+		if err != nil {
+			t.Fatalf("AnthropicAdapter SendMessage with full tool catalog failed: %v", err)
+		}
+		if msg == nil {
+			t.Fatal("expected non-nil message")
+		}
+		t.Logf("sub-test 6: AnthropicAdapter accepted the catalog; %d tool call(s); content=%q",
+			len(toolCalls), msg.Content)
+	})
+}
+
+// toolNames returns the Name field of each tool — used for readable test logs.
+func toolNames(ts []entity.Tool) []string {
+	names := make([]string, 0, len(ts))
+	for _, t := range ts {
+		names = append(names, t.Name)
+	}
+	return names
+}

--- a/internal/infrastructure/adapter/ai/warmup.go
+++ b/internal/infrastructure/adapter/ai/warmup.go
@@ -1,0 +1,98 @@
+// Package ai — warmup helpers prime Anthropic's compiled-grammar cache by
+// issuing a single tool-bearing request at startup. This amortizes the
+// 30-100s first-call latency that strict-mode tools incur before the
+// regional cache is warm.
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/anthony-bible/code-agent-demo/internal/domain/entity"
+	"github.com/anthony-bible/code-agent-demo/internal/domain/port"
+)
+
+// WarmCacheTimeout bounds the warm-up call. Anthropic's first-call grammar
+// compilation has been observed at ~70-100s in our tests, so we give it
+// ample headroom.
+const WarmCacheTimeout = 3 * time.Minute
+
+// WarmCache primes the AI provider's tool-schema cache by sending a minimal
+// request that carries the full tool catalog. The response is discarded.
+//
+// Cache invalidation is sensitive to the JSON schema structure and the SET
+// of tools in the request, per Anthropic's docs — so callers MUST pass the
+// exact same tool catalog (in the exact same shape) that real requests will
+// use. Tool order is normalized by ExecutorAdapter.ListTools, which sorts
+// by name; pass tools through that path rather than building them ad-hoc.
+//
+// Returns nil on success, or a wrapping error if the provider call fails.
+// The caller is expected to log+continue rather than fail startup: a cold
+// cache is a latency penalty, not a correctness problem.
+func WarmCache(
+	ctx context.Context,
+	p port.AIProvider,
+	tools []port.ToolParam,
+	log port.Logger,
+) error {
+	if p == nil {
+		return errors.New("warmup: AI provider is nil")
+	}
+	log = port.SafeLogger(log)
+
+	if len(tools) == 0 {
+		log.Info("warmup: skipping — no tools registered")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, WarmCacheTimeout)
+	defer cancel()
+
+	messages := []port.MessageParam{
+		{
+			Role:    entity.RoleUser,
+			Content: "ping",
+		},
+	}
+
+	// SystemPrompt set explicitly so getSystemPrompt skips the subagent
+	// listing path (which would issue extra I/O during warmup).
+	opts := port.AIRequestOptions{
+		SystemPrompt: "Reply with a single word.",
+	}
+
+	start := time.Now()
+	log.Info("warmup: priming AI provider grammar cache",
+		"tool_count", len(tools),
+		"timeout", WarmCacheTimeout,
+	)
+
+	if _, _, err := p.SendMessage(ctx, messages, tools, opts); err != nil {
+		return fmt.Errorf("warmup: SendMessage failed after %s: %w", time.Since(start), err)
+	}
+
+	log.Info("warmup: grammar cache primed",
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
+	return nil
+}
+
+// ToolParamsFromExecutor pulls the deterministic tool catalog from a
+// ToolExecutor and converts it via port.ToolParamFromEntity so the schema
+// fingerprint is identical to what real requests send.
+func ToolParamsFromExecutor(exec port.ToolExecutor) ([]port.ToolParam, error) {
+	if exec == nil {
+		return nil, errors.New("warmup: ToolExecutor is nil")
+	}
+	tools, err := exec.ListTools()
+	if err != nil {
+		return nil, fmt.Errorf("warmup: ListTools failed: %w", err)
+	}
+	out := make([]port.ToolParam, len(tools))
+	for i, t := range tools {
+		out[i] = port.ToolParamFromEntity(t)
+	}
+	return out, nil
+}

--- a/internal/infrastructure/adapter/ai/warmup_test.go
+++ b/internal/infrastructure/adapter/ai/warmup_test.go
@@ -1,0 +1,177 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/anthony-bible/code-agent-demo/internal/domain/entity"
+	"github.com/anthony-bible/code-agent-demo/internal/domain/port"
+)
+
+// fakeProvider is a port.AIProvider implementation that records SendMessage
+// calls and returns a configurable error. Only the methods exercised by the
+// warmup path have meaningful behavior; the rest exist to satisfy the
+// interface.
+type fakeProvider struct {
+	sendErr   error
+	sendCalls int
+}
+
+func (f *fakeProvider) SendMessage(
+	_ context.Context,
+	_ []port.MessageParam,
+	_ []port.ToolParam,
+	_ port.AIRequestOptions,
+) (*entity.Message, []port.ToolCallInfo, error) {
+	f.sendCalls++
+	if f.sendErr != nil {
+		return nil, nil, f.sendErr
+	}
+	return &entity.Message{}, nil, nil
+}
+
+func (f *fakeProvider) SendMessageStreaming(
+	_ context.Context,
+	_ []port.MessageParam,
+	_ []port.ToolParam,
+	_ port.AIRequestOptions,
+	_ port.StreamCallback,
+	_ port.ThinkingCallback,
+) (*entity.Message, []port.ToolCallInfo, error) {
+	return &entity.Message{}, nil, nil
+}
+
+func (f *fakeProvider) GenerateToolSchema() port.ToolInputSchemaParam {
+	return make(port.ToolInputSchemaParam)
+}
+
+func (f *fakeProvider) HealthCheck(_ context.Context) error { return nil }
+func (f *fakeProvider) SetModel(_ string) error             { return nil }
+func (f *fakeProvider) GetModel() string                    { return "" }
+func (f *fakeProvider) Clone() port.AIProvider              { return f }
+
+// fakeExecutor returns a configurable tool list and error from ListTools.
+// Other ToolExecutor methods are stubbed.
+type fakeExecutor struct {
+	tools   []entity.Tool
+	listErr error
+}
+
+func (f *fakeExecutor) RegisterTool(_ entity.Tool) error { return nil }
+func (f *fakeExecutor) UnregisterTool(_ string) error    { return nil }
+func (f *fakeExecutor) ExecuteTool(_ context.Context, _ string, _ interface{}) (string, error) {
+	return "", nil
+}
+
+func (f *fakeExecutor) ListTools() ([]entity.Tool, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.tools, nil
+}
+func (f *fakeExecutor) GetTool(_ string) (entity.Tool, bool)            { return entity.Tool{}, false }
+func (f *fakeExecutor) ValidateToolInput(_ string, _ interface{}) error { return nil }
+
+func TestWarmCache_NilProvider_ReturnsError(t *testing.T) {
+	t.Parallel()
+	tools := []port.ToolParam{{Name: "x"}}
+	err := WarmCache(context.Background(), nil, tools, port.NopLogger{})
+	if err == nil {
+		t.Fatal("expected error for nil provider, got nil")
+	}
+}
+
+func TestWarmCache_NoTools_SkipsWithoutCallingProvider(t *testing.T) {
+	t.Parallel()
+	p := &fakeProvider{}
+	if err := WarmCache(context.Background(), p, nil, port.NopLogger{}); err != nil {
+		t.Fatalf("expected nil error on empty tool catalog, got %v", err)
+	}
+	if p.sendCalls != 0 {
+		t.Errorf("expected SendMessage to be skipped, but it was called %d times", p.sendCalls)
+	}
+}
+
+func TestWarmCache_ProviderError_IsWrapped(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("upstream unavailable")
+	p := &fakeProvider{sendErr: sentinel}
+	tools := []port.ToolParam{{Name: "ping"}}
+
+	err := WarmCache(context.Background(), p, tools, port.NopLogger{})
+	if err == nil {
+		t.Fatal("expected error from provider, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error, got %v", err)
+	}
+	if p.sendCalls != 1 {
+		t.Errorf("expected exactly 1 SendMessage call, got %d", p.sendCalls)
+	}
+}
+
+func TestWarmCache_HappyPath_CallsProviderOnce(t *testing.T) {
+	t.Parallel()
+	p := &fakeProvider{}
+	tools := []port.ToolParam{{Name: "ping"}}
+	if err := WarmCache(context.Background(), p, tools, port.NopLogger{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.sendCalls != 1 {
+		t.Errorf("expected exactly 1 SendMessage call, got %d", p.sendCalls)
+	}
+}
+
+func TestWarmCache_NilLogger_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+	p := &fakeProvider{}
+	tools := []port.ToolParam{{Name: "ping"}}
+	if err := WarmCache(context.Background(), p, tools, nil); err != nil {
+		t.Fatalf("unexpected error with nil logger: %v", err)
+	}
+}
+
+func TestToolParamsFromExecutor_NilExecutor_ReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := ToolParamsFromExecutor(nil)
+	if err == nil {
+		t.Fatal("expected error for nil executor, got nil")
+	}
+}
+
+func TestToolParamsFromExecutor_ListToolsError_IsWrapped(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("disk fell off the truck")
+	exec := &fakeExecutor{listErr: sentinel}
+	_, err := ToolParamsFromExecutor(exec)
+	if err == nil {
+		t.Fatal("expected error from ListTools, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error, got %v", err)
+	}
+}
+
+func TestToolParamsFromExecutor_ConvertsAllTools(t *testing.T) {
+	t.Parallel()
+	exec := &fakeExecutor{
+		tools: []entity.Tool{
+			{Name: "a", Description: "tool a", Strict: true},
+			{Name: "b", Description: "tool b", Strict: false},
+		},
+	}
+	got, err := ToolParamsFromExecutor(exec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 ToolParams, got %d", len(got))
+	}
+	if got[0].Name != "a" || got[1].Name != "b" {
+		t.Errorf("tool order not preserved: %+v", got)
+	}
+	if !got[0].Strict || got[1].Strict {
+		t.Errorf("Strict flag not propagated: %+v", got)
+	}
+}

--- a/internal/infrastructure/adapter/tool/executor_bash_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_bash_tools.go
@@ -37,6 +37,13 @@ func (a *ExecutorAdapter) registerBashTool() {
 		ID:          toolNameBash,
 		Name:        toolNameBash,
 		Description: "Executes shell commands and returns stdout, stderr, and exit code. You MUST assess whether each command is dangerous and set the dangerous field accordingly. Dangerous commands require user confirmation.",
+		// Strict schema validation is opted in for write-capable / high-impact
+		// tools (bash, edit_file, delegate, task) so malformed inputs fail fast
+		// at the provider before doing damage. Read-only tools (read_file,
+		// list_files, fetch, plan/batch, skill, investigation) are left
+		// non-strict to avoid the strict-grammar compile cost where the blast
+		// radius of a malformed call is just a bad read.
+		Strict: true,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/internal/infrastructure/adapter/tool/executor_file_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_file_tools.go
@@ -118,6 +118,7 @@ func (a *ExecutorAdapter) registerFileTools() {
 		ID:          "edit_file",
 		Name:        "edit_file",
 		Description: "Makes edits to a text file. Replaces 'old_str' with 'new_str' in the given file. 'old_str' and 'new_str' MUST be different from each other. If the file specified with path doesn't exist, it will be created. The old_str must match exactly including whitespace and new lines. Include a few lines before to avoid editing a string with multiple matches.",
+		Strict:      true,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/internal/infrastructure/adapter/tool/executor_subagent_tools.go
+++ b/internal/infrastructure/adapter/tool/executor_subagent_tools.go
@@ -35,8 +35,9 @@ func (a *ExecutorAdapter) registerSubagentTools() {
 
 	// Register delegate tool
 	delegateTool := entity.Tool{
-		ID:   "delegate",
-		Name: "delegate",
+		ID:     "delegate",
+		Name:   "delegate",
+		Strict: true,
 		Description: `Launch a dynamic agent to handle complex, multi-step tasks autonomously.
 
 The delegate tool spawns a specialized agent (subprocess) that autonomously handles complex tasks in an isolated conversation context. You define the agent's role and behavior through a custom system prompt.
@@ -129,6 +130,7 @@ func (a *ExecutorAdapter) registerTaskTool() {
 		ID:          "task",
 		Name:        "task",
 		Description: fullDescription.String(),
+		Strict:      true,
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/internal/infrastructure/adapter/tool/tool_executor_adapter.go
+++ b/internal/infrastructure/adapter/tool/tool_executor_adapter.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
 
 	"github.com/anthony-bible/code-agent-demo/internal/application/usecase"
@@ -319,6 +320,11 @@ func (a *ExecutorAdapter) ListTools() ([]entity.Tool, error) {
 	for _, tool := range a.tools {
 		tools = append(tools, tool)
 	}
+	// Stable order keeps the tool-array fingerprint deterministic across
+	// requests so Anthropic's compiled-strict-schema cache can hit. Names are
+	// unique map keys so SliceStable behaves identically to Slice here, but the
+	// Stable variant better expresses the "deterministic order" intent.
+	sort.SliceStable(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
 	return tools, nil
 }
 

--- a/internal/infrastructure/adapter/webhook/http_adapter.go
+++ b/internal/infrastructure/adapter/webhook/http_adapter.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/anthony-bible/code-agent-demo/internal/domain/entity"
@@ -78,6 +79,16 @@ type HTTPAdapter struct {
 	// Protected by credsMu because SetBasicAuth may be called concurrently.
 	basicAuth map[string]basicAuthEntry
 	credsMu   sync.RWMutex
+	// warmupRequired marks readiness as gated on a successful warmup signal.
+	// When true, /ready returns 503 until warmupReady flips to true. When
+	// false (default), readiness is governed only by source registration —
+	// matching legacy behavior for callers that don't do warmup.
+	warmupRequired atomic.Bool
+	// warmupReady is set by MarkWarm once the warmup goroutine completes
+	// (success OR failure — a cold cache is a latency penalty, not a
+	// correctness issue, so we don't wedge the server forever on warmup
+	// errors).
+	warmupReady atomic.Bool
 }
 
 // NewHTTPAdapter creates a new webhook HTTP adapter.
@@ -124,7 +135,10 @@ func (a *HTTPAdapter) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
-// handleReady returns 200 OK if at least one alert source is registered.
+// handleReady returns 200 OK if at least one alert source is registered AND
+// any required warmup has completed. When warmup is gated (see
+// SetWarmupRequired), the endpoint returns 503 with status "warming up"
+// until MarkWarm is called.
 func (a *HTTPAdapter) handleReady(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
@@ -135,8 +149,34 @@ func (a *HTTPAdapter) handleReady(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	// Two separate atomic loads (no combined lock) leave a benign TOCTOU window:
+	// warmupReady may flip to true between the two reads, costing one extra 503
+	// response. The next poll will see 200. This is intentional — upgrading to a
+	// mutex would add contention to a hot read path for no observable benefit.
+	if a.warmupRequired.Load() && !a.warmupReady.Load() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"status":"warming up"}`))
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 	_, _ = fmt.Fprintf(w, `{"status":"ok","sources":%d}`, len(sources))
+}
+
+// SetWarmupRequired gates readiness on a successful MarkWarm signal. Call
+// this BEFORE Start if startup includes an async cache-warmup step. When
+// not called, readiness is governed solely by source registration (legacy
+// behavior).
+func (a *HTTPAdapter) SetWarmupRequired(required bool) {
+	a.warmupRequired.Store(required)
+}
+
+// MarkWarm flips the readiness gate to allow /ready to report 200 OK.
+// Safe to call multiple times. Should be called once the warmup goroutine
+// finishes — succeed OR fail; a cold cache is only a latency cost, not a
+// correctness one, so we don't wedge readiness on warmup errors.
+func (a *HTTPAdapter) MarkWarm() {
+	a.warmupReady.Store(true)
 }
 
 // SetBasicAuth registers HTTP Basic Auth credentials for a specific webhook path.

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -17,11 +17,29 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Supported AIProvider values. Used by the DI wiring in container.go to
+// select the AIProvider implementation.
+const (
+	ProviderAnthropic = "anthropic"
+	ProviderGenkit    = "genkit"
+)
+
 // Config holds all configuration values for the application.
 type Config struct {
 	// AIModel is the model identifier to use for AI requests.
 	// Defaults to "hf:zai-org/GLM-4.7"
 	AIModel string `mapstructure:"model"`
+
+	// AIProvider selects the AI provider implementation.
+	// Accepted values: "anthropic" (default), "genkit".
+	// Bound to AGENT_AI_PROVIDER.
+	AIProvider string `mapstructure:"ai_provider"`
+
+	// GenkitPlugin selects which Genkit plugin to load when AIProvider is
+	// "genkit". Accepted values are the names registered via
+	// ai.RegisterGenkitPlugin (built-ins: "anthropic"; defaults to "anthropic").
+	// Bound to AGENT_GENKIT_PLUGIN. Ignored when AIProvider != "genkit".
+	GenkitPlugin string `mapstructure:"genkit_plugin"`
 
 	// MaxTokens is the maximum number of tokens to generate in AI responses.
 	// Defaults to 20000
@@ -130,9 +148,11 @@ type SafetyConfig struct {
 // Defaults returns a Config struct with all default values set.
 func Defaults() *Config {
 	return &Config{
-		AIModel:    "hf:zai-org/GLM-4.7",
-		MaxTokens:  20000,
-		WorkingDir: ".",
+		AIModel:      "hf:zai-org/GLM-4.7",
+		AIProvider:   ProviderAnthropic,
+		GenkitPlugin: "anthropic",
+		MaxTokens:    20000,
+		WorkingDir:   ".",
 		UI: UIConfig{
 			WelcomeMessage: "Chat with Claude (use 'ctrl+c' to quit)",
 			GoodbyeMessage: "Bye!",

--- a/internal/infrastructure/config/container.go
+++ b/internal/infrastructure/config/container.go
@@ -120,7 +120,10 @@ func NewContainer(cfg *Config) (*Container, error) {
 		{Path: filepath.Join(getUserHome(), ".claude", "agents"), SourceType: entity.SubagentSourceUser},
 	})
 
-	aiAdapter := ai.NewAnthropicAdapter(cfg.AIModel, cfg.MaxTokens, subagentManager)
+	aiAdapter, err := newAIAdapter(cfg, subagentManager, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AI adapter: %w", err)
+	}
 
 	// Build validation config once; both the executor and investigation validator consume it
 	validationMode, validationWhitelist, err := buildValidationConfig(cfg)
@@ -461,6 +464,29 @@ func (c *Container) SubagentUseCase() *usecase.SubagentUseCase {
 // Use this to obtain the same logger that was injected into all components.
 func (c *Container) Logger() port.Logger {
 	return c.logger
+}
+
+// newAIAdapter selects and constructs the AIProvider implementation based on
+// cfg.AIProvider. Supported values: "anthropic" (default) and "genkit".
+// Any other value (including the empty string when not defaulted upstream)
+// is rejected with an error naming the bad value.
+func newAIAdapter(cfg *Config, subagentManager port.SubagentManager, log port.Logger) (port.AIProvider, error) {
+	// Default the provider when callers construct &Config{} directly without
+	// going through Defaults()/LoadConfig() — primarily test code in this
+	// package. Production callers always have AIProvider pre-populated.
+	provider := cfg.AIProvider
+	if provider == "" {
+		provider = ProviderAnthropic
+	}
+	switch provider {
+	case ProviderAnthropic:
+		return ai.NewAnthropicAdapter(cfg.AIModel, cfg.MaxTokens, subagentManager), nil
+	case ProviderGenkit:
+		return ai.NewGenkitAdapterWithPlugin(cfg.GenkitPlugin, cfg.AIModel, cfg.MaxTokens, subagentManager, log)
+	default:
+		return nil, fmt.Errorf("invalid AGENT_AI_PROVIDER %q: must be %q or %q",
+			provider, ProviderAnthropic, ProviderGenkit)
+	}
 }
 
 // getUserHome returns the user's home directory.


### PR DESCRIPTION
## Summary
- Wires the Genkit adapter into the container and config layer
- Adds \`WarmCache\` helper that primes the provider's compiled-grammar cache by issuing a tool-bearing request at startup
- Gates \`/ready\` on warmup completion so first real requests don't pay the 30-100s cache-miss cost
- Tool executor opts critical tools (bash, file, subagent) into \`Strict\` schema validation
- Adds Genkit adapter E2E test suite

**Stack:**
1. #64 → port + anthropic refactor + shared prompt
2. #65 → Genkit adapter core
3. **this PR** → wiring, warmup, serve integration

Base is set to \`pr/genkit-adapter\` so the diff reads cleanly; rebase to \`main\` after PRs 1+2 merge.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\` (all packages green)
- [ ] Manual \`serve\` smoke: confirm \`/ready\` returns 503 during warmup, 200 after
- [ ] E2E test with live Genkit provider
- [ ] Verify warmup is skipped when running under non-Genkit provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)