### PR TITLE
fix(investigation): forward registrar interface through PlanningExecutorAdapter

### DIFF
--- a/internal/infrastructure/adapter/tool/planning_executor_adapter.go
+++ b/internal/infrastructure/adapter/tool/planning_executor_adapter.go
@@ -89,6 +89,28 @@ func (p *PlanningExecutorAdapter) RegisterTool(tool entity.Tool) error {
 	return p.baseExecutor.RegisterTool(tool)
 }
 
+// Compile-time assertions that the decorator preserves the optional
+// investigation registrar interfaces implemented by the base executor.
+// Without these, runtime type assertions in InvestigationRunner silently
+// fail and report_investigation cannot find live investigations.
+var (
+	_ port.InvestigationRegistrar   = (*PlanningExecutorAdapter)(nil)
+	_ port.InvestigationDeregistrar = (*PlanningExecutorAdapter)(nil)
+)
+
+// RegisterInvestigation delegates to the base executor so that
+// report_investigation lookups succeed when this decorator is in front
+// of ExecutorAdapter.
+func (p *PlanningExecutorAdapter) RegisterInvestigation(investigationID string) {
+	p.baseExecutor.RegisterInvestigation(investigationID)
+}
+
+// DeregisterInvestigation delegates to the base executor to keep
+// investigation state cleanup symmetric with RegisterInvestigation.
+func (p *PlanningExecutorAdapter) DeregisterInvestigation(investigationID string) {
+	p.baseExecutor.DeregisterInvestigation(investigationID)
+}
+
 // UnregisterTool delegates to the base executor.
 func (p *PlanningExecutorAdapter) UnregisterTool(name string) error {
 	return p.baseExecutor.UnregisterTool(name)

--- a/internal/infrastructure/adapter/tool/planning_executor_adapter_test.go
+++ b/internal/infrastructure/adapter/tool/planning_executor_adapter_test.go
@@ -12,6 +12,44 @@ import (
 	"github.com/anthony-bible/code-agent-demo/internal/infrastructure/logger"
 )
 
+// TestPlanningExecutorAdapter_ForwardsInvestigationRegistration verifies that
+// the decorator forwards investigation registration to the base executor.
+// Regression test: previously the decorator did not implement
+// port.InvestigationRegistrar, so the runtime type assertion in
+// InvestigationRunner silently skipped registration and report_investigation
+// failed with "investigation_id not found".
+func TestPlanningExecutorAdapter_ForwardsInvestigationRegistration(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	fileManager := file.NewLocalFileManager(tempDir)
+	baseExecutor := NewExecutorAdapter(fileManager, logger.NewNop())
+	planningExecutor := NewPlanningExecutorAdapter(baseExecutor, fileManager, tempDir)
+
+	registrar, ok := any(planningExecutor).(port.InvestigationRegistrar)
+	if !ok {
+		t.Fatal("PlanningExecutorAdapter must implement port.InvestigationRegistrar")
+	}
+	deregistrar, ok := any(planningExecutor).(port.InvestigationDeregistrar)
+	if !ok {
+		t.Fatal("PlanningExecutorAdapter must implement port.InvestigationDeregistrar")
+	}
+
+	const invID = "inv-test-decorator-forward-1"
+	registrar.RegisterInvestigation(invID)
+
+	report := []byte(`{"investigation_id":"` + invID + `","message":"halfway there","progress":50}`)
+	if _, err := planningExecutor.ExecuteTool(context.Background(), "report_investigation", report); err != nil {
+		t.Fatalf("report_investigation after Register should succeed via decorator, got: %v", err)
+	}
+
+	deregistrar.DeregisterInvestigation(invID)
+
+	if _, err := planningExecutor.ExecuteTool(context.Background(), "report_investigation", report); err == nil {
+		t.Fatal("report_investigation after Deregister should fail, got nil error")
+	}
+}
+
 func TestPlanningExecutorAdapter_EditFileBlockedInPlanMode(t *testing.T) {
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- `report_investigation` always failed with `investigation_id "..." not found` whenever the AI tried to post a progress update during a headless alert investigation.
- Root cause: `InvestigationRunner.registerInvestigation` does a runtime type assertion to `port.InvestigationRegistrar` on the tool executor. The executor wired in `container.go` is `*PlanningExecutorAdapter`, which did **not** implement that interface. The assertion silently returned `ok=false`, so registration was skipped and the base executor's `investigationStates` map stayed empty.
- Fix: forward `RegisterInvestigation` / `DeregisterInvestigation` through the decorator to the wrapped `*ExecutorAdapter`, plus compile-time `var _ port.InvestigationRegistrar = (*PlanningExecutorAdapter)(nil)` assertions so this can't regress silently.

## Why it stayed hidden

`requireInvestigationExists` is only called from `executeReportInvestigation`. `complete_investigation` and `escalate_investigation` skip the check, so any investigation where the model jumped straight to completion looked fine. The bug surfaced as soon as the model used `report_investigation` for a progress update mid-investigation.

## Test plan

- [x] `go test ./internal/infrastructure/adapter/tool/ -run PlanningExecutorAdapter_ForwardsInvestigationRegistration` — new regression test passes.
- [x] Local end-to-end run against the Anthropic provider: webhook → investigation → `report_investigation` invoked twice with `result_bytes>0` (no "not found" error) → `status=completed` with 7 findings + RCA correlation.
- [ ] Re-run the same flow against the Genkit provider once outstanding Genkit retry behavior is sorted (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)