### PR TITLE
fix(docker): bump builder to golang:1.25.10-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.24.11-bookworm AS builder
+FROM golang:1.25.10-bookworm AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- `go.mod` requires Go >= 1.25.0, but the Dockerfile builder stage was pinned to `golang:1.24.11-bookworm`, causing `go mod download` to fail in the Build & Push Image workflow.
- Bumps the builder image to `golang:1.25.10-bookworm` (latest patch in the 1.25 line, matching the prior pin precision).

Fixes the failing job: https://github.com/Anthony-Bible/code-agent-demo/actions/runs/25968520347/job/76336235373

## Test plan
- [ ] CI Build & Push Image job succeeds on this branch
- [ ] Resulting image runs `code-agent-demo serve` without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)